### PR TITLE
sso: makefile and dist.sh 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+version := "v1.0.0"
+
+build: dist/sso-auth dist/sso-proxy
+
+dist/sso-auth: 
+	mkdir -p dist
+	go build -o dist/sso-auth ./cmd/sso-auth
+
+dist/sso-proxy: 
+	mkdir -p dist
+	go build -o dist/sso-proxy ./cmd/sso-proxy
+
+test: 
+	./scripts/test
+
+clean:
+	rm -r dist

--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# 1. commit to bump the version and update the changelog/readme
+# 2. tag that commit
+# 3. use dist.sh to produce tar.gz
+# 4. update the release metadata on github / upload the binaries there too
+
+set -e
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+rm -rf   $DIR/dist
+mkdir -p $DIR/dist
+
+arch=$(go env GOARCH)
+version='1.0.0'
+goversion=$(go version | awk '{print $3}')
+
+echo "... building v$version for $linux/$arch"
+TARGET="sso-$version-linux-$arch-$goversion"
+GOOS=linux GOARCH=amd64\
+    make build
+sudo chown -R 0:0 dist
+echo "...tar-ing dist to $TARGET"
+cd dist && tar czvf ../$TARGET.tar.gz . && cd -


### PR DESCRIPTION
## What
This adds a Makefile that we can use to run the dist.sh script in order to create tars of the binaries for releases. 
cc @buzzfeed/infra-security 