### PR TITLE
Check error on setting cookie store

### DIFF
--- a/internal/auth/authenticator.go
+++ b/internal/auth/authenticator.go
@@ -128,6 +128,10 @@ func SetCookieStore(opts *Options) func(*Authenticator) error {
 				return nil
 			}, setPayloads(opts))
 
+		if err != nil {
+			return err
+		}
+
 		a.csrfStore = cookieStore
 		a.sessionStore = cookieStore
 		a.AuthCodeCipher = authCodeCipher


### PR DESCRIPTION
If the options funcs should error out the loop returns earlier than
expected thus putting the application in a bad state for storing
cookies.