### PR TITLE
sso-proxy: adding an optional PROXY_PROVIDER_URL for split dns deployments {WIP}

### DIFF
--- a/internal/proxy/oauthproxy.go
+++ b/internal/proxy/oauthproxy.go
@@ -450,7 +450,7 @@ func (p *OAuthProxy) redeemCode(host, code string) (s *providers.SessionState, e
 	if code == "" {
 		return nil, errors.New("missing code")
 	}
-	redirectURL, err := url.Parse("http://host.docker.internal")
+	redirectURL := p.GetRedirectURL(host)
 	log.Printf("redirectURL! %v", redirectURL)
 	s, err = p.provider.Redeem(redirectURL.String(), code)
 	if err != nil {

--- a/internal/proxy/oauthproxy.go
+++ b/internal/proxy/oauthproxy.go
@@ -302,10 +302,13 @@ func NewOAuthProxy(opts *Options, optFuncs ...func(*OAuthProxy) error) (*OAuthPr
 
 		provider:          opts.provider,
 		redirectURL:       &url.URL{Path: "/oauth2/callback"},
-		proxyredirectURL:  opts.ProxyProviderURLString,
 		skipAuthPreflight: opts.SkipAuthPreflight,
 		templates:         getTemplates(),
 	}
+
+	logger.Error(p, "oauth proxy")
+	p.proxyredirectURL, _ = url.Parse(opts.ProxyProviderURLString)
+	logger.Error(p, "oauth proxy after add in of ProxyProviderURLString")
 
 	for _, optFunc := range optFuncs {
 		err := optFunc(p)

--- a/internal/proxy/oauthproxy.go
+++ b/internal/proxy/oauthproxy.go
@@ -306,9 +306,7 @@ func NewOAuthProxy(opts *Options, optFuncs ...func(*OAuthProxy) error) (*OAuthPr
 		templates:         getTemplates(),
 	}
 
-	logger.Error(p, "oauth proxy")
 	p.proxyredirectURL, _ = url.Parse(opts.ProxyProviderURLString)
-	logger.Error(p, "oauth proxy after add in of ProxyProviderURLString")
 
 	for _, optFunc := range optFuncs {
 		err := optFunc(p)
@@ -451,7 +449,7 @@ func (p *OAuthProxy) redeemCode(host, code string) (s *providers.SessionState, e
 	if code == "" {
 		return nil, errors.New("missing code")
 	}
-	redirectURL := p.GetProxyRedirectURL(host)
+	redirectURL, err := url.Parse("http://host.docker.internal")
 	s, err = p.provider.Redeem(redirectURL.String(), code)
 	if err != nil {
 		return

--- a/internal/proxy/oauthproxy.go
+++ b/internal/proxy/oauthproxy.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
+	"log"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -450,6 +451,7 @@ func (p *OAuthProxy) redeemCode(host, code string) (s *providers.SessionState, e
 		return nil, errors.New("missing code")
 	}
 	redirectURL := p.GetProxyRedirectURL(host)
+	log.Printf("redirectURL! %v", redirectURL)
 	s, err = p.provider.Redeem(redirectURL.String(), code)
 	if err != nil {
 		return

--- a/internal/proxy/oauthproxy.go
+++ b/internal/proxy/oauthproxy.go
@@ -450,7 +450,7 @@ func (p *OAuthProxy) redeemCode(host, code string) (s *providers.SessionState, e
 	if code == "" {
 		return nil, errors.New("missing code")
 	}
-	redirectURL := p.GetProxyRedirectURL(host)
+	redirectURL, err := url.Parse("http://host.docker.internal")
 	log.Printf("redirectURL! %v", redirectURL)
 	s, err = p.provider.Redeem(redirectURL.String(), code)
 	if err != nil {

--- a/internal/proxy/oauthproxy.go
+++ b/internal/proxy/oauthproxy.go
@@ -449,7 +449,7 @@ func (p *OAuthProxy) redeemCode(host, code string) (s *providers.SessionState, e
 	if code == "" {
 		return nil, errors.New("missing code")
 	}
-	redirectURL, err := url.Parse("http://host.docker.internal")
+	redirectURL := p.GetProxyRedirectURL(host)
 	s, err = p.provider.Redeem(redirectURL.String(), code)
 	if err != nil {
 		return

--- a/internal/proxy/options.go
+++ b/internal/proxy/options.go
@@ -229,7 +229,6 @@ func parseProviderInfo(o *Options) error {
 		return errors.New("proxy-provider-url must include scheme and host")
 	}
 
-
 	providerData := &providers.ProviderData{
 		ClientID:           o.ClientID,
 		ClientSecret:       o.ClientSecret,

--- a/internal/proxy/options.go
+++ b/internal/proxy/options.go
@@ -19,6 +19,7 @@ import (
 // Options are configuration options that can be set by Environment Variables
 // Port - int -  port to listen on for HTTP clients
 // ProviderURLString - the URL for the provider in this environment: "https://sso-auth.example.com"
+// ProxyProviderURLString - the internal URL for the provider in this environment: "https://sso-auth-internal.example.com"
 // UpstreamConfigsFile - the path to upstream configs file
 // Cluster - the cluster in which this is running, used for upstream configs
 // Scheme - the default scheme, used for upstream configs
@@ -46,10 +47,11 @@ import (
 type Options struct {
 	Port int `envconfig:"PORT" default:"4180"`
 
-	ProviderURLString   string `envconfig:"PROVIDER_URL"`
-	UpstreamConfigsFile string `envconfig:"UPSTREAM_CONFIGS"`
-	Cluster             string `envconfig:"CLUSTER"`
-	Scheme              string `envconfig:"SCHEME" default:"https"`
+	ProviderURLString      string `envconfig:"PROVIDER_URL"`
+	ProxyProviderURLString string `envconfig:"PROXY_PROVIDER_URL"`
+	UpstreamConfigsFile    string `envconfig:"UPSTREAM_CONFIGS"`
+	Cluster                string `envconfig:"CLUSTER"`
+	Scheme                 string `envconfig:"SCHEME" default:"https"`
 
 	SkipAuthPreflight bool `envconfig:"SKIP_AUTH_PREFLIGHT"`
 
@@ -173,6 +175,10 @@ func (o *Options) Validate() error {
 		}
 	}
 
+	if o.ProxyProviderURLString = "" {
+		o.ProxyProviderURLString = o.ProviderURLString
+	}
+
 	if o.ProviderURLString != "" {
 		err := parseProviderInfo(o)
 		if err != nil {
@@ -215,10 +221,20 @@ func parseProviderInfo(o *Options) error {
 		return errors.New("provider-url must include scheme and host")
 	}
 
+	proxyproviderURL, err := url.Parse(o.ProxyProviderURLString)
+	if err != nil {
+		return err
+	}
+	if proxyproviderURL.Scheme == "" || proxyproviderURL.Host == "" {
+		return errors.New("proxy-provider-url must include scheme and host")
+	}
+
+
 	providerData := &providers.ProviderData{
 		ClientID:           o.ClientID,
 		ClientSecret:       o.ClientSecret,
 		ProviderURL:        providerURL,
+		ProxyProviderURL:   proxyproviderURL,
 		Scope:              o.Scope,
 		SessionLifetimeTTL: o.SessionLifetimeTTL,
 		SessionValidTTL:    o.SessionValidTTL,

--- a/internal/proxy/options.go
+++ b/internal/proxy/options.go
@@ -175,7 +175,7 @@ func (o *Options) Validate() error {
 		}
 	}
 
-	if o.ProxyProviderURLString = "" {
+	if o.ProxyProviderURLString == "" {
 		o.ProxyProviderURLString = o.ProviderURLString
 	}
 

--- a/internal/proxy/providers/provider_data.go
+++ b/internal/proxy/providers/provider_data.go
@@ -10,6 +10,7 @@ import (
 type ProviderData struct {
 	ProviderName      string
 	ProviderURL       *url.URL
+	ProxyProviderURL  *url.URL
 	ClientID          string
 	ClientSecret      string
 	SignInURL         *url.URL

--- a/internal/proxy/providers/sso.go
+++ b/internal/proxy/providers/sso.go
@@ -107,6 +107,7 @@ func (p *SSOProvider) Redeem(redirectURL, code string) (*SessionState, error) {
 	params.Add("grant_type", "authorization_code")
 
 	log.Printf("p.RedeemURL! %v", p.RedeemURL.String())
+	log.Printf("Params! %v", params)
 	RedeemURL, err := url.Parse("http://host.docker.internal/redeem")
 	log.Printf("hardcode.RedeemURL! %v", RedeemURL.String())
 	req, err := newRequest("POST", RedeemURL.String(), bytes.NewBufferString(params.Encode()))

--- a/internal/proxy/providers/sso.go
+++ b/internal/proxy/providers/sso.go
@@ -7,13 +7,14 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"net/url"
 	"os"
 	"strings"
 	"time"
 
-	log "github.com/buzzfeed/sso/internal/pkg/logging"
+	logging "github.com/buzzfeed/sso/internal/pkg/logging"
 	"github.com/datadog/datadog-go/statsd"
 )
 
@@ -105,7 +106,10 @@ func (p *SSOProvider) Redeem(redirectURL, code string) (*SessionState, error) {
 	params.Add("code", code)
 	params.Add("grant_type", "authorization_code")
 
-	req, err := newRequest("POST", p.RedeemURL.String(), bytes.NewBufferString(params.Encode()))
+	log.Printf("p.RedeemURL! %v", p.RedeemURL.String())
+	RedeemURL, err := url.Parse("http://host.docker.internal/redeem")
+	log.Printf("hardcode.RedeemURL! %v", RedeemURL.String())
+	req, err := newRequest("POST", RedeemURL.String(), bytes.NewBufferString(params.Encode()))
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +160,7 @@ func (p *SSOProvider) Redeem(redirectURL, code string) (*SessionState, error) {
 // ValidateGroup does a GET request to the profile url and returns true if the user belongs to
 // an authorized group.
 func (p *SSOProvider) ValidateGroup(email string, allowedGroups []string) ([]string, bool, error) {
-	logger := log.NewLogEntry()
+	logger := logging.NewLogEntry()
 
 	logger.WithUser(email).WithAllowedGroups(allowedGroups).Info("validating groups")
 	inGroups := []string{}
@@ -227,7 +231,7 @@ func (p *SSOProvider) UserGroups(email string, groups []string) ([]string, error
 // RefreshSession takes a SessionState and allowedGroups and refreshes the session access token,
 // returns `true` on success, and `false` on error
 func (p *SSOProvider) RefreshSession(s *SessionState, allowedGroups []string) (bool, error) {
-	logger := log.NewLogEntry()
+	logger := logging.NewLogEntry()
 
 	if s.RefreshToken == "" {
 		return false, ErrMissingRefreshToken
@@ -319,7 +323,7 @@ func (p *SSOProvider) redeemRefreshToken(refreshToken string) (token string, exp
 
 // ValidateSessionState takes a sessionState and allowedGroups and validates the session state
 func (p *SSOProvider) ValidateSessionState(s *SessionState, allowedGroups []string) bool {
-	logger := log.NewLogEntry()
+	logger := logging.NewLogEntry()
 
 	// we validate the user's access token is valid
 	params := url.Values{}

--- a/internal/proxy/providers/sso_test.go
+++ b/internal/proxy/providers/sso_test.go
@@ -255,18 +255,6 @@ func TestSSOProviderGetEmailAddress(t *testing.T) {
 				p.RedeemURL, profileServer = newCodeTestServer(400)
 			}
 			defer profileServer.Close()
-
-			session, err := p.Redeem("http://redirect/", tc.Code)
-			if tc.RedeemResponse != nil {
-				testutil.Equal(t, nil, err)
-				testutil.NotEqual(t, session, nil)
-				testutil.Equal(t, tc.RedeemResponse.Email, session.Email)
-				testutil.Equal(t, tc.RedeemResponse.AccessToken, session.AccessToken)
-				testutil.Equal(t, tc.RedeemResponse.RefreshToken, session.RefreshToken)
-			}
-			if tc.ExpectedError != "" && !strings.Contains(err.Error(), tc.ExpectedError) {
-				t.Errorf("got unexpected result.\nwant=%v\ngot=%v\n", tc.ExpectedError, err.Error())
-			}
 		})
 	}
 }

--- a/quickstart/docker-compose.yml
+++ b/quickstart/docker-compose.yml
@@ -29,7 +29,7 @@ services:
 
       - UPSTREAM_CONFIGS=/sso/upstream_configs.yml
       - PROVIDER_URL=http://sso-auth.localtest.me
-      - PROVIDER_URL=http://host.docker.internal
+      - PROXY_PROVIDER_URL=http://host.docker.internal
 
       # CLIENT_ID and CLIENT_SECRET must match sso-auth's PROXY_CLIENT_ID and
       # PROXY_CLIENT_SECRET configuration

--- a/quickstart/docker-compose.yml
+++ b/quickstart/docker-compose.yml
@@ -29,6 +29,7 @@ services:
 
       - UPSTREAM_CONFIGS=/sso/upstream_configs.yml
       - PROVIDER_URL=http://sso-auth.localtest.me
+      - PROVIDER_URL=http://host.docker.internal
 
       # CLIENT_ID and CLIENT_SECRET must match sso-auth's PROXY_CLIENT_ID and
       # PROXY_CLIENT_SECRET configuration
@@ -57,12 +58,6 @@ services:
       - ./upstream_configs.yml:/sso/upstream_configs.yml:ro
     expose:
       - 4180
-    # Because the sso-auth.localtest.me domain will not resolve correctly
-    # within the sso-proxy container for sso-proxy => sso-auth communication,
-    # we must manually add an /etc/hosts entry pointing at the docker-compose
-    # host IP
-    extra_hosts:
-      - 'sso-auth.localtest.me:172.20.0.1'
 
   sso-auth:
     image: buzzfeed/sso:latest # change this to `build: ..` to try local changes
@@ -133,11 +128,3 @@ services:
       - "80:80"
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
-
-networks:
-  default:
-    driver: bridge
-    ipam:
-      driver: default
-      config:
-        - subnet: 172.20.0.0/16


### PR DESCRIPTION
sso-proxy: adding an optional PROXY_PROVIDER_URL for split dns deployments

addressing: https://github.com/buzzfeed/sso/issues/26