### PR TITLE
Don't check in the dist/ directory created by make

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 # quickstart process and may contain secrets
 env
 
+# Don't check in the dist/ directory created by make
+dist/
 
 # Compiled source #
 ###################
@@ -54,4 +56,3 @@ __pycache__/
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
-


### PR DESCRIPTION
Currently the `dist/` directory created by `make` isn't in `.gitignore` but it probably should be.