### PR TITLE
Make TLS verification of upstream servers configurable

### DIFF
--- a/internal/proxy/oauthproxy_test.go
+++ b/internal/proxy/oauthproxy_test.go
@@ -77,7 +77,7 @@ func TestNewReverseProxy(t *testing.T) {
 	backendHost := net.JoinHostPort(backendHostname, backendPort)
 	proxyURL, _ := url.Parse(backendURL.Scheme + "://" + backendHost + "/")
 
-	proxyHandler := NewReverseProxy(proxyURL)
+	proxyHandler := NewReverseProxy(proxyURL, &UpstreamConfig{TLSSkipVerify: false})
 	frontend := httptest.NewServer(proxyHandler)
 	defer frontend.Close()
 
@@ -109,7 +109,7 @@ func TestNewRewriteReverseProxy(t *testing.T) {
 		},
 	}
 
-	rewriteProxy := NewRewriteReverseProxy(route)
+	rewriteProxy := NewRewriteReverseProxy(route, &UpstreamConfig{TLSSkipVerify: false})
 
 	frontend := httptest.NewServer(rewriteProxy)
 	defer frontend.Close()
@@ -156,7 +156,7 @@ func TestNewReverseProxyHostname(t *testing.T) {
 		t.Fatalf("expected to parse to url: %s", err)
 	}
 
-	reverseProxy := NewReverseProxy(toURL)
+	reverseProxy := NewReverseProxy(toURL, &UpstreamConfig{TLSSkipVerify: false})
 	from := httptest.NewServer(reverseProxy)
 	defer from.Close()
 
@@ -199,6 +199,70 @@ func TestNewReverseProxyHostname(t *testing.T) {
 		t.Errorf("expected Cookie header to be empty but was %s", res.Header.Get("Cookie"))
 	}
 
+}
+
+func TestNewReverseProxyTLSSkipVerify(t *testing.T) {
+	type respStruct struct {
+		HandshakeComplete bool `json:"handshake-complete"`
+	}
+
+	testCases := []struct {
+		name           string
+		skipVerify     bool
+		expectedStatus int
+	}{
+		{
+			name:           "skip verify true",
+			skipVerify:     true,
+			expectedStatus: 200,
+		},
+		{
+			name:           "skip verify false",
+			skipVerify:     false,
+			expectedStatus: 502,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			to := httptest.NewTLSServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+				body, err := json.Marshal(
+					// Doesn't really matter what's sent since we should 502
+					&respStruct{
+						HandshakeComplete: r.TLS.HandshakeComplete,
+					},
+				)
+				if err != nil {
+					t.Fatalf("expected to marshal json: %s", err)
+				}
+				rw.Write(body)
+			}))
+			defer to.Close()
+
+			toURL, err := url.Parse(to.URL)
+			if err != nil {
+				t.Fatalf("expected to parse to url: %s", err)
+			}
+
+			reverseProxy := NewReverseProxy(toURL, &UpstreamConfig{TLSSkipVerify: tc.skipVerify})
+			from := httptest.NewServer(reverseProxy)
+			defer from.Close()
+
+			res, err := http.Get(from.URL)
+			if err != nil {
+				t.Fatalf("expected to be able to make req: %s", err)
+			}
+
+			if res.StatusCode != tc.expectedStatus {
+				t.Logf(" got status code: %v", res.StatusCode)
+				t.Logf("want status code: %d", tc.expectedStatus)
+
+				t.Errorf("got unexpected response code for tls failure")
+			}
+			if res.Header.Get("Cookie") != "" {
+				t.Errorf("expected Cookie header to be empty but was %s", res.Header.Get("Cookie"))
+			}
+		})
+	}
 }
 
 func TestDeleteSSOHeader(t *testing.T) {
@@ -271,7 +335,7 @@ func TestRoundTrip(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			req := httptest.NewRequest("GET", tc.url, nil)
-			ut := upstreamTransport{}
+			ut := newUpstreamTransport(false)
 			resp, err := ut.RoundTrip(req)
 			if err == nil && tc.expectedError {
 				t.Errorf("expected error but error was nil")
@@ -300,7 +364,7 @@ func TestEncodedSlashes(t *testing.T) {
 	defer backend.Close()
 
 	b, _ := url.Parse(backend.URL)
-	proxyHandler := NewReverseProxy(b)
+	proxyHandler := NewReverseProxy(b, &UpstreamConfig{TLSSkipVerify: false})
 	frontend := httptest.NewServer(proxyHandler)
 	defer frontend.Close()
 

--- a/internal/proxy/proxy_config.go
+++ b/internal/proxy/proxy_config.go
@@ -52,6 +52,7 @@ type UpstreamConfig struct {
 
 	SkipAuthCompiledRegex []*regexp.Regexp
 	AllowedGroups         []string
+	TLSSkipVerify         bool
 	HMACAuth              hmacauth.HmacAuth
 	Timeout               time.Duration
 	FlushInterval         time.Duration
@@ -79,6 +80,7 @@ type OptionsConfig struct {
 	HeaderOverrides map[string]string `yaml:"header_overrides"`
 	SkipAuthRegex   []string          `yaml:"skip_auth_regex"`
 	AllowedGroups   []string          `yaml:"allowed_groups"`
+	TLSSkipVerify   bool              `yaml:"tls_skip_verify"`
 	Timeout         time.Duration     `yaml:"timeout"`
 	FlushInterval   time.Duration     `yaml:"flush_interval"`
 }
@@ -109,7 +111,7 @@ func loadServiceConfigs(raw []byte, cluster, scheme string, configVars map[strin
 	// we don't set this to the len(serviceConfig) since not all service configs
 	// are configured for all clusters, leaving nil tail pointers in the slice.
 	configs := make([]*UpstreamConfig, 0)
-	// resovle overrides
+	// resolve overrides
 	for _, service := range serviceConfigs {
 		proxy, err := resolveUpstreamConfig(service, cluster)
 		if err != nil {
@@ -362,6 +364,7 @@ func parseOptionsConfig(proxy *UpstreamConfig) error {
 	proxy.Timeout = proxy.RouteConfig.Options.Timeout
 	proxy.FlushInterval = proxy.RouteConfig.Options.FlushInterval
 	proxy.HeaderOverrides = proxy.RouteConfig.Options.HeaderOverrides
+	proxy.TLSSkipVerify = proxy.RouteConfig.Options.TLSSkipVerify
 
 	proxy.RouteConfig.Options = nil
 


### PR DESCRIPTION
When pointing the proxy directly at an AWS ALB, e.g., the cert presented by the ALB is guaranteed to be invalid, as you can't get a cert for `*.elb.amazonaws.com`. Depending on your deployment setup you may or may not be able to easily automate creation of corresponding DNS records to match your certs. And of course your certs might be self-signed. Therefore it's desirable to be able to disable TLS verification for upstream servers in some cases. Particularly because the real security barrier is the necessary firewall rule that ensures nothing else can talk to the upstream server.

Fixes #47.