### PR TITLE
circle: limit imagepush to project owners

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,9 @@ jobs:
           command: |
             make dist/sso-proxy
       - run:
-          name: push sso-dev image
-          command: |
-            make imagepush
+            name: push sso-dev image
+            command: |
+              if [[ -z "${CIRCLE_PROJECT_OWNER_KEY}" ]]; then
+                docker login -u $DOCKER_USER -p $DOCKER_PASS
+                make imagepush
+              fi

--- a/Makefile
+++ b/Makefile
@@ -4,21 +4,20 @@ commit := $(shell git rev-parse --short HEAD)
 
 build: dist/sso-auth dist/sso-proxy
 
-dist/sso-auth: 
+dist/sso-auth:
 	mkdir -p dist
 	go build -o dist/sso-auth ./cmd/sso-auth
 
-dist/sso-proxy: 
+dist/sso-proxy:
 	mkdir -p dist
 	go build -o dist/sso-proxy ./cmd/sso-proxy
 
-test: 
+test:
 	./scripts/test
 
 clean:
 	rm -r dist
 
-imagepush: 
+imagepush:
 	docker build -t buzzfeed/sso-dev:$(commit) .
-	docker login -u $(DOCKER_USER) -p $(DOCKER_PASS)
 	docker push buzzfeed/sso-dev:$(commit)


### PR DESCRIPTION
## Problem

Currently, outside collaborators' circle builds are breaking because of the `imagepush` command.

## Solution

Depend on an env present to run the command, otherwise skip it. 