### PR TITLE
simplify secret validation

### DIFF
--- a/internal/auth/authenticator.go
+++ b/internal/auth/authenticator.go
@@ -89,14 +89,17 @@ type getProfileResponse struct {
 // SetCookieStore sets the cookie store to use a miscreant cipher
 func SetCookieStore(opts *Options) func(*Authenticator) error {
 	return func(a *Authenticator) error {
-
-		authCodeCipher, err := aead.NewMiscreantCipher(sessions.SecretBytes(opts.AuthCodeSecret))
+		decodedAuthCodeSecret, err := base64.StdEncoding.DecodeString(opts.AuthCodeSecret)
+		if err != nil {
+			return err
+		}
+		authCodeCipher, err := aead.NewMiscreantCipher([]byte(decodedAuthCodeSecret))
 		if err != nil {
 			return err
 		}
 
 		cookieStore, err := sessions.NewCookieStore(opts.CookieName,
-			sessions.CreateMiscreantCookieCipher(opts.CookieSecret),
+			sessions.CreateMiscreantCookieCipher(opts.decodedCookieSecret),
 			func(c *sessions.CookieStore) error {
 				c.CookieDomain = opts.CookieDomain
 				c.CookieHTTPOnly = opts.CookieHTTPOnly

--- a/internal/auth/authenticator_test.go
+++ b/internal/auth/authenticator_test.go
@@ -66,8 +66,9 @@ func setTestProvider(provider *providers.TestProvider) func(*Authenticator) erro
 	}
 }
 
-var testEncodedCookieSecret = base64.URLEncoding.EncodeToString([]byte("574b776a7c934d6b9fc42ec63a389f79"))
-var testAuthCodeSecret = base64.URLEncoding.EncodeToString([]byte("52592f914a1a499e8462724f4a9bf40a"))
+// generated using `openssl rand 32 -base64`
+var testEncodedCookieSecret = "x7xzsM1Ky4vGQPwqy6uTztfr3jtm/pIdRbJXgE0q8kU="
+var testAuthCodeSecret = "qICChm3wdjbjcWymm7PefwtPP6/PZv+udkFEubTeE38="
 
 func testOpts(proxyClientID, proxyClientSecret string) *Options {
 	opts := NewOptions()

--- a/internal/auth/options_test.go
+++ b/internal/auth/options_test.go
@@ -46,7 +46,7 @@ func TestNewOptions(t *testing.T) {
 		"missing setting: proxy-client-id",
 		"missing setting: proxy-client-secret",
 		"missing setting: required-host-header",
-		"cookie_secret must be 32 or 64 bytes to create an AES cipher but is 0 bytes.",
+		"Invalid value for COOKIE_SECRET; must decode to 32 or 64 bytes, but decoded to 0 bytes",
 		"missing setting: no host specified for statsd metrics collections",
 		"missing setting: no port specified for statsd metrics collections",
 	})
@@ -100,7 +100,7 @@ func TestCookieRefreshMustBeLessThanCookieExpire(t *testing.T) {
 	o := testOptions()
 	testutil.Equal(t, nil, o.Validate())
 
-	o.CookieSecret = "yHBw2lh2Cvo6aI_jn_qMTr-pRAjtq0nzVgDJNb36jgQ="
+	o.CookieSecret = testEncodedCookieSecret
 	o.CookieRefresh = o.CookieExpire
 	testutil.NotEqual(t, nil, o.Validate())
 
@@ -113,11 +113,11 @@ func TestBase64CookieSecret(t *testing.T) {
 	testutil.Equal(t, nil, o.Validate())
 
 	// 32 byte, base64 (urlsafe) encoded key
-	o.CookieSecret = "yHBw2lh2Cvo6aI_jn_qMTr-pRAjtq0nzVgDJNb36jgQ="
+	o.CookieSecret = testEncodedCookieSecret
 	testutil.Equal(t, nil, o.Validate())
 
 	// 32 byte, base64 (urlsafe) encoded key, w/o padding
-	o.CookieSecret = "yHBw2lh2Cvo6aI_jn_qMTr-pRAjtq0nzVgDJNb36jgQ"
+	o.CookieSecret = testEncodedCookieSecret
 	testutil.Equal(t, nil, o.Validate())
 }
 

--- a/internal/pkg/aead/aead_test.go
+++ b/internal/pkg/aead/aead_test.go
@@ -10,9 +10,9 @@ import (
 )
 
 func TestEncodeAndDecodeAccessToken(t *testing.T) {
-	key := []byte("0123456789abcdefghijklmnopqrstuv")
 	plaintext := []byte("my plain text value")
 
+	key := GenerateKey()
 	c, err := NewMiscreantCipher([]byte(key))
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
@@ -40,7 +40,7 @@ func TestEncodeAndDecodeAccessToken(t *testing.T) {
 }
 
 func TestMarshalAndUnmarshalStruct(t *testing.T) {
-	key := []byte("0123456789abcdefghijklmnopqrstuv")
+	key := GenerateKey()
 
 	c, err := NewMiscreantCipher([]byte(key))
 	if err != nil {

--- a/internal/pkg/sessions/cookie_store.go
+++ b/internal/pkg/sessions/cookie_store.go
@@ -34,7 +34,6 @@ type SessionStore interface {
 type CookieStore struct {
 	Name               string
 	CSRFCookieName     string
-	CookieSecret       string
 	CookieExpire       time.Duration
 	CookieRefresh      time.Duration
 	CookieSecure       bool
@@ -68,10 +67,9 @@ func addPadding(secret string) string {
 }
 
 // CreateMiscreantCookieCipher creates a new miscreant cipher with the cookie secret
-func CreateMiscreantCookieCipher(cookieSecret string) func(s *CookieStore) error {
+func CreateMiscreantCookieCipher(cookieSecret []byte) func(s *CookieStore) error {
 	return func(s *CookieStore) error {
-		s.CookieSecret = cookieSecret
-		cipher, err := aead.NewMiscreantCipher(SecretBytes(s.CookieSecret))
+		cipher, err := aead.NewMiscreantCipher(cookieSecret)
 		if err != nil {
 			return fmt.Errorf("miscreant cookie-secret error: %s", err.Error())
 		}

--- a/internal/pkg/sessions/cookie_store_test.go
+++ b/internal/pkg/sessions/cookie_store_test.go
@@ -11,12 +11,12 @@ import (
 	"github.com/buzzfeed/sso/internal/pkg/testutil"
 )
 
-var testEncodedCookieSecret = base64.URLEncoding.EncodeToString([]byte("574b776a7c934d6b9fc42ec63a389f79"))
+var testEncodedCookieSecret, _ = base64.StdEncoding.DecodeString("qICChm3wdjbjcWymm7PefwtPP6/PZv+udkFEubTeE38=")
 
 func TestCreateMiscreantCookieCipher(t *testing.T) {
 	testCases := []struct {
 		name          string
-		cookieSecret  string
+		cookieSecret  []byte
 		expectedError bool
 	}{
 		{
@@ -26,7 +26,7 @@ func TestCreateMiscreantCookieCipher(t *testing.T) {
 
 		{
 			name:          "error when not base64 encoded",
-			cookieSecret:  "abcd",
+			cookieSecret:  []byte("abcd"),
 			expectedError: true,
 		},
 	}

--- a/internal/pkg/sessions/session_state_test.go
+++ b/internal/pkg/sessions/session_state_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestSessionStateSerialization(t *testing.T) {
-	secret := "0123456789abcdefghijklmnopqrstuv"
-
+	secret := aead.GenerateKey()
 	c, err := aead.NewMiscreantCipher([]byte(secret))
 	if err != nil {
 		t.Fatalf("expected to be able to create cipher: %v", err)

--- a/internal/proxy/oauthproxy.go
+++ b/internal/proxy/oauthproxy.go
@@ -251,8 +251,7 @@ func NewOAuthProxy(opts *Options, optFuncs ...func(*OAuthProxy) error) (*OAuthPr
 	logger.WithCookieName(opts.CookieName).WithCookieSecure(
 		opts.CookieSecure).WithCookieHTTPOnly(opts.CookieHTTPOnly).WithCookieExpire(
 		opts.CookieExpire).WithCookieDomain(domain).Info()
-
-	cipher, err := aead.NewMiscreantCipher(secretBytes(opts.CookieSecret))
+	cipher, err := aead.NewMiscreantCipher(opts.decodedCookieSecret)
 	if err != nil {
 		return nil, fmt.Errorf("cookie-secret error: %s", err.Error())
 	}
@@ -270,7 +269,7 @@ func NewOAuthProxy(opts *Options, optFuncs ...func(*OAuthProxy) error) (*OAuthPr
 		CookieHTTPOnly: opts.CookieHTTPOnly,
 		CookieName:     opts.CookieName,
 		CookieSecure:   opts.CookieSecure,
-		CookieSeed:     opts.CookieSecret,
+		CookieSeed:     string(opts.decodedCookieSecret),
 		CSRFCookieName: fmt.Sprintf("%v_%v", opts.CookieName, "csrf"),
 
 		StatsdClient: opts.StatsdClient,

--- a/internal/proxy/oauthproxy_test.go
+++ b/internal/proxy/oauthproxy_test.go
@@ -2,7 +2,6 @@ package proxy
 
 import (
 	"crypto"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -19,14 +18,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/buzzfeed/sso/internal/pkg/aead"
-	"github.com/buzzfeed/sso/internal/proxy/providers"
-
 	"github.com/18F/hmacauth"
+	"github.com/buzzfeed/sso/internal/pkg/aead"
 	"github.com/buzzfeed/sso/internal/pkg/testutil"
+	"github.com/buzzfeed/sso/internal/proxy/providers"
 )
 
-var testEncodedCookieSecret = base64.URLEncoding.EncodeToString([]byte("574b776a7c934d6b9fc42ec63a389f79"))
+var testEncodedCookieSecret = "tJgzIEug8M/6Asjn5mvpWxxef5d5duU7BwpuD0GCHRI="
 
 func init() {
 	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)

--- a/internal/proxy/options_test.go
+++ b/internal/proxy/options_test.go
@@ -51,6 +51,7 @@ func TestNewOptions(t *testing.T) {
 		"missing setting: client-secret",
 		"missing setting: statsd-host",
 		"missing setting: statsd-port",
+		"Invalid value for COOKIE_SECRET; must decode to 32 or 64 bytes, but decoded to 0 bytes",
 	})
 	testutil.Equal(t, expected, err.Error())
 }
@@ -143,11 +144,11 @@ func TestBase64CookieSecret(t *testing.T) {
 	testutil.Equal(t, nil, o.Validate())
 
 	// 32 byte, base64 (urlsafe) encoded key
-	o.CookieSecret = "yHBw2lh2Cvo6aI_jn_qMTr-pRAjtq0nzVgDJNb36jgQ="
+	o.CookieSecret = testEncodedCookieSecret
 	testutil.Equal(t, nil, o.Validate())
 
 	// 32 byte, base64 (urlsafe) encoded key, w/o padding
-	o.CookieSecret = "yHBw2lh2Cvo6aI_jn_qMTr-pRAjtq0nzVgDJNb36jgQ"
+	o.CookieSecret = testEncodedCookieSecret
 	testutil.Equal(t, nil, o.Validate())
 
 	testutil.Equal(t, nil, o.Validate())

--- a/internal/proxy/providers/session_state_test.go
+++ b/internal/proxy/providers/session_state_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestSessionStateSerialization(t *testing.T) {
-	secret := "0123456789abcdefghijklmnopqrstuv"
-
+	secret := aead.GenerateKey()
 	c, err := aead.NewMiscreantCipher([]byte(secret))
 	if err != nil {
 		t.Fatalf("expected to be able to create cipher: %v", err)

--- a/quickstart/docker-compose.yml
+++ b/quickstart/docker-compose.yml
@@ -37,7 +37,7 @@ services:
 
       # XXX: These secrets are for demonstration purposes only! Use
       #
-      #     openssl rand -base64 32 | head -c 32 | base64
+      #     openssl rand -base64 32
       #
       # to generate your own.
       - AUTH_CODE_SECRET=SVM0NEFMUUlaZGxyaFVhOGxsQ0wvOFYyZTh2S2Fha1U=
@@ -83,7 +83,7 @@ services:
 
       # XXX: These secrets are for demonstration purposes only! Use
       #
-      #     openssl rand -base64 32 | head -c 32 | base64
+      #     openssl rand -base64 32
       #
       # to generate your own.
       - AUTH_CODE_SECRET=c1kxTHcyN3FwdGRiZHpZRU15TUpNdFlpb1ZEUUw5R3M=


### PR DESCRIPTION
## Problem
This addresses https://github.com/buzzfeed/sso/issues/40. 

## Solution
This makes validation of cookie secrets more strict, allowing only for a base64 encoded 32-byte secret. 

Cookie secrets should be able to be created using 
`openssl rand 32 -base64` 

cc @buzzfeed/sso-maintainers 