### PR TITLE
proxy: manage session failure with restart of oauth flow

### DIFF
--- a/internal/auth/authenticator.go
+++ b/internal/auth/authenticator.go
@@ -341,7 +341,7 @@ func (p *Authenticator) SignIn(rw http.ResponseWriter, req *http.Request) {
 		p.ProxyOAuthRedirect(rw, req, session, tags)
 	case http.ErrNoCookie:
 		p.SignInPage(rw, req, http.StatusOK)
-	case sessions.ErrLifetimeExpired:
+	case sessions.ErrLifetimeExpired, sessions.ErrInvalidSession:
 		p.sessionStore.ClearSession(rw, req)
 		p.SignInPage(rw, req, http.StatusOK)
 	default:

--- a/internal/pkg/aead/aead.go
+++ b/internal/pkg/aead/aead.go
@@ -98,7 +98,7 @@ func (c *MiscreantCipher) Marshal(s interface{}) (string, error) {
 	}
 
 	// base64-encode the result
-	encoded := base64.URLEncoding.EncodeToString(ciphertext)
+	encoded := base64.RawURLEncoding.EncodeToString(ciphertext)
 	return encoded, nil
 }
 
@@ -106,7 +106,7 @@ func (c *MiscreantCipher) Marshal(s interface{}) (string, error) {
 // byte slice the pased cipher, and unmarshals the resulting JSON into the struct pointer passed
 func (c *MiscreantCipher) Unmarshal(value string, s interface{}) error {
 	// convert base64 string value to bytes
-	ciphertext, err := base64.URLEncoding.DecodeString(value)
+	ciphertext, err := base64.RawURLEncoding.DecodeString(value)
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/sessions/cookie_store_test.go
+++ b/internal/pkg/sessions/cookie_store_test.go
@@ -299,13 +299,13 @@ func TestLoadCookiedSession(t *testing.T) {
 		name          string
 		optFuncs      []func(*CookieStore) error
 		setupCookies  func(*testing.T, *http.Request, *CookieStore, *SessionState)
-		expectedError bool
+		expectedError error
 		sessionState  *SessionState
 	}{
 		{
 			name:          "no cookie set returns an error",
 			setupCookies:  func(*testing.T, *http.Request, *CookieStore, *SessionState) {},
-			expectedError: true,
+			expectedError: http.ErrNoCookie,
 		},
 		{
 			name:     "cookie set with cipher set",
@@ -328,7 +328,7 @@ func TestLoadCookiedSession(t *testing.T) {
 				value := "574b776a7c934d6b9fc42ec63a389f79"
 				req.AddCookie(s.makeSessionCookie(req, value, time.Hour, time.Now()))
 			},
-			expectedError: true,
+			expectedError: ErrInvalidSession,
 		},
 	}
 
@@ -339,10 +339,8 @@ func TestLoadCookiedSession(t *testing.T) {
 			req := httptest.NewRequest("GET", "https://www.example.com", nil)
 			tc.setupCookies(t, req, session, tc.sessionState)
 			s, err := session.LoadSession(req)
-			if err != nil {
-				testutil.Assert(t, tc.expectedError, "error expected")
-				return
-			}
+
+			testutil.Equal(t, tc.expectedError, err)
 			testutil.Equal(t, tc.sessionState, s)
 
 		})

--- a/internal/proxy/oauthproxy.go
+++ b/internal/proxy/oauthproxy.go
@@ -859,7 +859,7 @@ func (p *OAuthProxy) Proxy(rw http.ResponseWriter, req *http.Request) {
 			// The user session is invalid and we can't decode it.
 			// This can happen for a variety of reasons but the most common non-malicious
 			// case occurs when the session encoding schema changes. We manage this ux
-			// by trigger the start of a new oauth flow.
+			// by triggering the start of the oauth flow.
 			p.OAuthStart(rw, req, tags)
 			return
 		default:

--- a/internal/proxy/oauthproxy.go
+++ b/internal/proxy/oauthproxy.go
@@ -45,6 +45,7 @@ var (
 	ErrLifetimeExpired   = errors.New("user lifetime expired")
 	ErrUserNotAuthorized = errors.New("user not authorized")
 	ErrUnknownHost       = errors.New("unknown host")
+	ErrInvalidSession    = errors.New("invalid session")
 )
 
 const statusInvalidHost = 421
@@ -465,6 +466,8 @@ func (p *OAuthProxy) SetSessionCookie(rw http.ResponseWriter, req *http.Request,
 
 // LoadCookiedSession returns a SessionState from the cookie in the request.
 func (p *OAuthProxy) LoadCookiedSession(req *http.Request) (*providers.SessionState, error) {
+	logger := log.NewLogEntry().WithRemoteAddress(getRemoteAddr(req))
+
 	c, err := req.Cookie(p.CookieName)
 	if err != nil {
 		// always http.ErrNoCookie
@@ -473,7 +476,10 @@ func (p *OAuthProxy) LoadCookiedSession(req *http.Request) (*providers.SessionSt
 
 	session, err := providers.UnmarshalSession(c.Value, p.CookieCipher)
 	if err != nil {
-		return nil, err
+		tags := []string{"error:unmarshaling_session"}
+		p.StatsdClient.Incr("application_error", tags, 1.0)
+		logger.Error(err, "unable to unmarshal session")
+		return nil, ErrInvalidSession
 	}
 
 	return session, nil
@@ -643,7 +649,7 @@ func (p *OAuthProxy) OAuthStart(rw http.ResponseWriter, req *http.Request, tags 
 	// this value will be unique since we always use a randomized nonce as part of marshaling
 	encryptedState, err := p.CookieCipher.Marshal(state)
 	if err != nil {
-		tags = append(tags, "error_marshalling_state_parameter")
+		tags = append(tags, "error:marshaling_state_parameter")
 		p.StatsdClient.Incr("application_error", tags, 1.0)
 		logger.Error(err, "failed to marshal state parameter for state query parameter")
 		p.ErrorPage(rw, req, http.StatusInternalServerError, "Internal Error", err.Error())
@@ -849,6 +855,13 @@ func (p *OAuthProxy) Proxy(rw http.ResponseWriter, req *http.Request) {
 			// User's lifetime expired, we trigger the start of the oauth flow
 			p.OAuthStart(rw, req, tags)
 			return
+		case ErrInvalidSession:
+			// The user session is invalid and we can't decode it.
+			// This can happen for a variety of reasons but the most common non-malicious
+			// case occurs when the session encoding schema changes. We manage this ux
+			// by trigger the start of a new oauth flow.
+			p.OAuthStart(rw, req, tags)
+			return
 		default:
 			logger.Error(err, "unknown error authenticating user")
 			tags = append(tags, "error:internal_error")
@@ -878,10 +891,8 @@ func (p *OAuthProxy) Proxy(rw http.ResponseWriter, req *http.Request) {
 // Authenticate authenticates a request by checking for a session cookie, and validating its expiration,
 // clearing the session cookie if it's invalid and returning an error if necessary..
 func (p *OAuthProxy) Authenticate(rw http.ResponseWriter, req *http.Request) (err error) {
-	logger := log.NewLogEntry()
+	logger := log.NewLogEntry().WithRemoteAddress(getRemoteAddr(req))
 
-	// use for logging
-	remoteAddr := getRemoteAddr(req)
 	route, ok := p.router(req)
 	if !ok {
 		logger.WithRequestHost(req.Host).Info(
@@ -900,7 +911,7 @@ func (p *OAuthProxy) Authenticate(rw http.ResponseWriter, req *http.Request) (er
 	session, err := p.LoadCookiedSession(req)
 	if err != nil {
 		// We loaded a cookie but it wasn't valid, clear it, and reject the request
-		logger.WithRemoteAddress(remoteAddr).Error(err, "error authenticating user")
+		logger.Error(err, "error authenticating user")
 		return err
 	}
 


### PR DESCRIPTION
## Problem

It is occasionally necessary to modify the session encoding, either as improvements are made or we want to rotate secrets.

When this occurs, since each upstream session is invalidated, it creates an unpleasant user experience where a user gets a `500` on each initial visit to every upstream.

This poor ux adds unnecessary resistance to updating or modifying the session encoding. While schema changes and/or secret rotations should be taken lightly, we should be confident to make those changes with as minimal impact to UX as possible.

## Solution

Instead of rendering a `500` error in loading an invalid session, we should trigger the start of a new OAuth flow. Our implicit login mechanism should mask this error for most applications and users should be seamlessly re-logged in.

## Notes

This will not work for all applications, particularly applications that do not/cannot follow redirects to finish the OAuth flow