### PR TITLE
sso: add metrics to reverse proxy

### DIFF
--- a/internal/proxy/proxy_config.go
+++ b/internal/proxy/proxy_config.go
@@ -17,6 +17,10 @@ const (
 	rewrite = "rewrite"
 )
 
+var (
+	space = regexp.MustCompile(`\s+`)
+)
+
 // ServiceConfig represents the configuration for a given service
 type ServiceConfig struct {
 	Service        string                     `yaml:"service"`
@@ -302,7 +306,7 @@ func resolveUpstreamConfig(service *ServiceConfig, override string) (*UpstreamCo
 		return nil, err
 	}
 
-	dst.Service = service.Service
+	dst.Service = cleanWhiteSpace(service.Service)
 	return dst, nil
 }
 
@@ -362,4 +366,9 @@ func parseOptionsConfig(proxy *UpstreamConfig) error {
 	proxy.RouteConfig.Options = nil
 
 	return nil
+}
+
+func cleanWhiteSpace(s string) string {
+	// This trims all white space from a service name and collapses all remaining space to `_`
+	return space.ReplaceAllString(strings.TrimSpace(s), "_") //
 }


### PR DESCRIPTION
## Problem

We're investigating some reports of latency potentially introduced by the proxy.  We don't have great timing metrics isolated around the reverse proxy.

## Solution

I'd like to add more metrics around the reverse proxy specifically in an attempt to narrow down what's introducing the latency.

## Notes

We have overhead metrics as well as overall latency metrics, and while useful, they don't report on the latency of upstreams themselves.