### PR TITLE
ENV vars exclude BUZZFEED_ prefix

### DIFF
--- a/docs/google_provider_setup.md
+++ b/docs/google_provider_setup.md
@@ -122,8 +122,8 @@ have been filled in, click the "Authorize" button.
 To give `sso-auth` permission to access Google Group information for users, the following
 environment variables must be set:
 
-- **`BUZZFEED_GOOGLE_ADMIN_EMAIL`**: An administrative email address on your organization's
+- **`GOOGLE_ADMIN_EMAIL`**: An administrative email address on your organization's
 domain, the identity of which can be assumed by `sso`.
-- **`BUZZFEED_GOOGLE_SERVICE_ACCOUNT_JSON`**: The path to the JSON file downloaded at the time of
+- **`GOOGLE_SERVICE_ACCOUNT_JSON`**: The path to the JSON file downloaded at the time of
 service account creation above. There is no reason why this file should ever be accessed by any
 person or service other than `sso`; ensure that file permissions are set accordingly.


### PR DESCRIPTION
## Problem

Docs show the ENV vars as:

BUZZFEED_GOOGLE_ADMIN_EMAIL
BUZZFEED_GOOGLE_SERVICE_ACCOUNT_JSON

when they should be:

GOOGLE_ADMIN_EMAIL
GOOGLE_SERVICE_ACCOUNT_JSON

## Solution

list them in the docs as:

GOOGLE_ADMIN_EMAIL
GOOGLE_SERVICE_ACCOUNT_JSON
