### PR TITLE
cop_auth: host domain should respond to ping

### DIFF
--- a/internal/auth/authenticator.go
+++ b/internal/auth/authenticator.go
@@ -171,6 +171,7 @@ func (p *Authenticator) newMux() http.Handler {
 
 	// we setup our service mux to handle service routes that use the required host header
 	serviceMux := http.NewServeMux()
+	serviceMux.HandleFunc("/ping", p.withMethods(p.PingPage, "GET"))
 	serviceMux.HandleFunc("/robots.txt", p.withMethods(p.RobotsTxt, "GET"))
 	serviceMux.HandleFunc("/start", p.withMethods(p.OAuthStart, "GET"))
 	serviceMux.HandleFunc("/sign_in", p.withMethods(p.validateClientID(p.validateRedirectURI(p.validateSignature(p.SignIn))), "GET"))


### PR DESCRIPTION
## Problem

We identified a strange bug in our routing logic in which the `/ping` endpoint was getting a `404` **_if and only if_** we used the configured host in the request. So any requests that used any other host responded with a `200` :bug:.

This is a result of the way we've set up our mux in combination with go's default mux handling. Patterns that match a `host` domains take precedent, so when the mux receives the request with the host we've configured, it walks down the mux subtree that matched with the host and `404`'s since we haven't set up a handler for `/ping` in that mux subtree.

However, if we use a host that is not configured, the pattern does not match on the `host` domain and falls into our catchall which we've configured to respond to `/ping` requests.

## Solution

We configure `/ping` on the configured host patterns also.

## Notes

So `/ping` should now respond to all domains, regardless of what the host was passed in the request.

cc @pyoio 
