### PR TITLE
proxy: logging handling/logging of oauth start on xml requests

### DIFF
--- a/internal/proxy/oauthproxy_test.go
+++ b/internal/proxy/oauthproxy_test.go
@@ -1295,6 +1295,15 @@ func TestProxyXHRErrorHandling(t *testing.T) {
 			ExpectedCode: http.StatusUnauthorized,
 		},
 		{
+			Name:    "no session should return error code when XMLHttpRequest",
+			Session: nil,
+			Method:  "GET",
+			Header: map[string]string{
+				"X-Requested-With": "XMLHttpRequest",
+			},
+			ExpectedCode: http.StatusUnauthorized,
+		},
+		{
 			Name: "valid session should proxy as normal when XMLHttpRequest",
 			Session: &providers.SessionState{
 				LifetimeDeadline: time.Now().Add(time.Duration(1) * time.Hour),


### PR DESCRIPTION
## Problem

XHR error handling was creating obscure corner cases due to some bugs in the request flow.

## Solution

Improve logging to better note handling of these requests as well as fix a bug in the request flow.
