### PR TITLE
quickstart: add link to kubernetes blog post and example

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,6 +4,8 @@ This quickstart guide will walk you through the process of creating a set of
 Google OAuth credentials and using Docker Compose to run an example deployment
 of **sso** protecting two upstream services.
 
+To learn how to get started using SSO with Kubernetes, you can check out this [blog post](https://medium.com/@while1eq1/single-sign-on-for-internal-apps-in-kubernetes-using-google-oauth-sso-2386a34bc433) and [example](/quickstart/kubernetes), added and written by [Bill Broach](https://twitter.com/while1eq1), one our community contributors! 
+
 
 ## Prerequisites
 
@@ -21,7 +23,6 @@ The rest of this guide will assume you are in the `quickstart` subdirectory of
 the repo:
 
     cd sso/quickstart
-
 
 ## 2. Create Google OAuth Credentials
 


### PR DESCRIPTION
This adds a link to the kubernetes blog post and example to the quickstart guide. 

cc @buzzfeed/sso-maintainers 