### PR TITLE
Refactor provider options

### DIFF
--- a/cmd/sso-auth/main.go
+++ b/cmd/sso-auth/main.go
@@ -37,7 +37,7 @@ func main() {
 		return nil
 	}
 
-	authenticator, err := auth.NewAuthenticator(opts, emailValidator, auth.SetCookieStore(opts), auth.AssignStatsdClient(opts))
+	authenticator, err := auth.NewAuthenticator(opts, emailValidator, auth.AssignProvider(opts), auth.SetCookieStore(opts), auth.AssignStatsdClient(opts))
 	if err != nil {
 		logger.Error(err, "error creating new Authenticator")
 		os.Exit(1)

--- a/internal/auth/authenticator.go
+++ b/internal/auth/authenticator.go
@@ -144,7 +144,6 @@ func NewAuthenticator(opts *Options, optionFuncs ...func(*Authenticator) error) 
 		Host:              opts.Host,
 		CookieSecure:      opts.CookieSecure,
 
-		provider:           opts.provider,
 		redirectURL:        redirectURL,
 		SetXAuthRequest:    opts.SetXAuthRequest,
 		PassUserHeaders:    opts.PassUserHeaders,

--- a/internal/auth/options_test.go
+++ b/internal/auth/options_test.go
@@ -53,21 +53,6 @@ func TestNewOptions(t *testing.T) {
 	testutil.Equal(t, expected, err.Error())
 }
 
-func TestGoogleGroupInvalidFile(t *testing.T) {
-	defer func() {
-		r := recover()
-		panicMsg := "could not read google credentials file"
-		if r != panicMsg {
-			t.Errorf("expected panic with message %s but got %s", panicMsg, r)
-		}
-	}()
-	o := testOptions()
-	o.GoogleAdminEmail = "admin@example.com"
-	o.GoogleServiceAccountJSON = "file_doesnt_exist.json"
-	o.Validate()
-
-}
-
 func TestInitializedOptions(t *testing.T) {
 	o := testOptions()
 	testutil.Equal(t, nil, o.Validate())
@@ -82,18 +67,6 @@ func TestRedirectURL(t *testing.T) {
 	expected := &url.URL{
 		Scheme: "https", Host: "myhost.com", Path: "/oauth2/callback"}
 	testutil.Equal(t, expected, o.redirectURL)
-}
-
-func TestDefaultProviderApiSettings(t *testing.T) {
-	o := testOptions()
-	testutil.Equal(t, nil, o.Validate())
-	p := o.provider.Data()
-	testutil.Equal(t, "https://accounts.google.com/o/oauth2/auth?access_type=offline",
-		p.SignInURL.String())
-	testutil.Equal(t, "https://www.googleapis.com/oauth2/v3/token",
-		p.RedeemURL.String())
-	testutil.Equal(t, "", p.ProfileURL.String())
-	testutil.Equal(t, "profile email", p.Scope)
 }
 
 func TestCookieRefreshMustBeLessThanCookieExpire(t *testing.T) {

--- a/internal/auth/providers/google.go
+++ b/internal/auth/providers/google.go
@@ -31,7 +31,16 @@ type GoogleProvider struct {
 }
 
 // NewGoogleProvider returns a new GoogleProvider and sets the provider url endpoints.
-func NewGoogleProvider(p *ProviderData, adminEmail, credsFilePath string) *GoogleProvider {
+func NewGoogleProvider(p *ProviderData, adminEmail, credsFilePath string) (*GoogleProvider, error) {
+	if adminEmail != "" || credsFilePath != "" {
+		if adminEmail == "" {
+			return nil, errors.New("missing setting: google-admin-email")
+		}
+		if credsFilePath == "" {
+			return nil, errors.New("missing setting: google-service-account-json")
+		}
+	}
+
 	p.ProviderName = "Google"
 	if p.SignInURL.String() == "" {
 		p.SignInURL = &url.URL{Scheme: "https",
@@ -77,14 +86,14 @@ func NewGoogleProvider(p *ProviderData, adminEmail, credsFilePath string) *Googl
 	if credsFilePath != "" {
 		credsReader, err := os.Open(credsFilePath)
 		if err != nil {
-			panic("could not read google credentials file")
+			return nil, errors.New("could not read google credentials file")
 		}
 		googleProvider.AdminService = &GoogleAdminService{
 			adminService: getAdminService(adminEmail, credsReader),
 			cb:           googleProvider.cb,
 		}
 	}
-	return googleProvider
+	return googleProvider, nil
 }
 
 // SetStatsdClient sets the google provider and admin service statsd client

--- a/internal/auth/providers/google_test.go
+++ b/internal/auth/providers/google_test.go
@@ -37,7 +37,8 @@ func newGoogleProvider(providerData *ProviderData) *GoogleProvider {
 			ValidateURL:  &url.URL{},
 			Scope:        ""}
 	}
-	return NewGoogleProvider(providerData, "", "")
+	provider, _ := NewGoogleProvider(providerData, "", "")
+	return provider
 }
 
 func TestGoogleProviderDefaults(t *testing.T) {

--- a/internal/auth/providers/providers.go
+++ b/internal/auth/providers/providers.go
@@ -24,6 +24,11 @@ var (
 	ErrServiceUnavailable = errors.New("SERVICE_UNAVAILABLE")
 )
 
+const (
+	// GoogleProviderName identifies the Google provider
+	GoogleProviderName = "google"
+)
+
 // Provider is an interface exposing functions necessary to authenticate with a given provider.
 type Provider interface {
 	Data() *ProviderData


### PR DESCRIPTION
Introduces a simple `switch` to initialize the provider to allow for new providers to be subsequently added.

I did consider removing the `TestGoogleGroupInvalidFile` function and including it in `TestNewOptions`, since it no longer requires a `panic` recovery, but that seemed like maybe the wrong solution once multiple providers are introduced.

Fixes #6.