### PR TITLE
sso-proxy: adding an optional PROXY_PROVIDER_URL for split dns deployments

### DIFF
--- a/internal/proxy/providers/provider_data.go
+++ b/internal/proxy/providers/provider_data.go
@@ -10,11 +10,13 @@ import (
 type ProviderData struct {
 	ProviderName      string
 	ProviderURL       *url.URL
+	ProxyProviderURL  *url.URL
 	ClientID          string
 	ClientSecret      string
 	SignInURL         *url.URL
 	SignOutURL        *url.URL
 	RedeemURL         *url.URL
+	ProxyRedeemURL    *url.URL
 	RefreshURL        *url.URL
 	ProfileURL        *url.URL
 	ProtectedResource *url.URL

--- a/internal/proxy/providers/sso.go
+++ b/internal/proxy/providers/sso.go
@@ -60,6 +60,7 @@ func NewSSOProvider(p *ProviderData, sc *statsd.Client) *SSOProvider {
 	p.RefreshURL = base.ResolveReference(&url.URL{Path: "/refresh"})
 	p.ValidateURL = base.ResolveReference(&url.URL{Path: "/validate"})
 	p.ProfileURL = base.ResolveReference(&url.URL{Path: "/profile"})
+	p.ProxyRedeemURL = p.ProxyProviderURL.ResolveReference(&url.URL{Path: "/redeem"})
 	return &SSOProvider{
 		ProviderData: p,
 		StatsdClient: sc,
@@ -105,10 +106,11 @@ func (p *SSOProvider) Redeem(redirectURL, code string) (*SessionState, error) {
 	params.Add("code", code)
 	params.Add("grant_type", "authorization_code")
 
-	req, err := newRequest("POST", p.RedeemURL.String(), bytes.NewBufferString(params.Encode()))
+	req, err := newRequest("POST", p.ProxyRedeemURL.String(), bytes.NewBufferString(params.Encode()))
 	if err != nil {
 		return nil, err
 	}
+	req.Host = p.RedeemURL.Host
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	resp, err := httpClient.Do(req)
 	if err != nil {

--- a/quickstart/docker-compose.yml
+++ b/quickstart/docker-compose.yml
@@ -29,6 +29,7 @@ services:
 
       - UPSTREAM_CONFIGS=/sso/upstream_configs.yml
       - PROVIDER_URL=http://sso-auth.localtest.me
+      - PROXY_PROVIDER_URL=http://host.docker.internal
 
       # CLIENT_ID and CLIENT_SECRET must match sso-auth's PROXY_CLIENT_ID and
       # PROXY_CLIENT_SECRET configuration
@@ -57,12 +58,6 @@ services:
       - ./upstream_configs.yml:/sso/upstream_configs.yml:ro
     expose:
       - 4180
-    # Because the sso-auth.localtest.me domain will not resolve correctly
-    # within the sso-proxy container for sso-proxy => sso-auth communication,
-    # we must manually add an /etc/hosts entry pointing at the docker-compose
-    # host IP
-    extra_hosts:
-      - 'sso-auth.localtest.me:172.20.0.1'
 
   sso-auth:
     image: buzzfeed/sso:latest # change this to `build: ..` to try local changes
@@ -101,7 +96,7 @@ services:
       - OLD_COOKIE_SECRET=V2JBZk0zWGtsL29UcFUvWjVDWWQ2UHExNXJ0b2VhcDI=
 
       # Tells nginx-proxy service how to route requests to this service
-      - VIRTUAL_HOST=sso-auth.localtest.me
+      - VIRTUAL_HOST=sso-auth.localtest.me,host.docker.internal
     expose:
       - 4180
 
@@ -133,11 +128,3 @@ services:
       - "80:80"
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
-
-networks:
-  default:
-    driver: bridge
-    ipam:
-      driver: default
-      config:
-        - subnet: 172.20.0.0/16


### PR DESCRIPTION
sso-proxy: adding an optional PROXY_PROVIDER_URL for split dns deployments

addressing: https://github.com/buzzfeed/sso/issues/26
