### PR TITLE
bump golint to golang.org/x/lint/golint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - setup_remote_docker
       - run:
           name: get lint
-          command: go get github.com/golang/lint/golint
+          command: go get golang.org/x/lint/golint
       - run:
           name: install dependencies
           command: |


### PR DESCRIPTION
## Problem

CircleCi failed:

#!/bin/bash -eo pipefail
go get github.com/golang/lint/golint
package github.com/golang/lint/golint: code in directory /go/src/github.com/golang/lint/golint expects import "golang.org/x/lint/golint"
Exited with code 1

## Solution

bump golint to golang.org/x/lint/golint

