### PR TITLE
quickstart: remove references to OLD_COOKIE_SECRET

### DIFF
--- a/quickstart/docker-compose.yml
+++ b/quickstart/docker-compose.yml
@@ -92,9 +92,6 @@ services:
       - STATSD_HOST=127.0.0.1
       - STATSD_PORT=8125
 
-      # TODO: remove the need for this config value
-      - OLD_COOKIE_SECRET=V2JBZk0zWGtsL29UcFUvWjVDWWQ2UHExNXJ0b2VhcDI=
-
       # Tells nginx-proxy service how to route requests to this service
       - VIRTUAL_HOST=sso-auth.localtest.me,host.docker.internal
     expose:

--- a/quickstart/kubernetes/sso-auth-deployment.yml
+++ b/quickstart/kubernetes/sso-auth-deployment.yml
@@ -64,12 +64,6 @@ spec:
               secretKeyRef:
                 name: auth-cookie-secret
                 key: auth-cookie-secret
-          # OLD_COOKIE_SECRET is the same as COOKIE_SECRET, not sure why its even needed at this point
-          - name: OLD_COOKIE_SECRET
-            valueFrom:
-              secretKeyRef:
-                name: auth-cookie-secret
-                key: auth-cookie-secret
           # STATSD_HOST and STATSD_PORT must be defined or the app wont launch, they dont need to be a real host / port
           - name: STATSD_HOST
             value: localhost


### PR DESCRIPTION
Cleanup `OLD_COOKIE_SECRET` references, fixes #29.