### PR TITLE
sso-proxy: sign out redirect URL should use ‘cookieSecure’

### DIFF
--- a/internal/proxy/oauthproxy.go
+++ b/internal/proxy/oauthproxy.go
@@ -681,8 +681,20 @@ func (p *OAuthProxy) isXHR(req *http.Request) bool {
 // SignOut redirects the request to the provider's sign out url.
 func (p *OAuthProxy) SignOut(rw http.ResponseWriter, req *http.Request) {
 	p.ClearSessionCookie(rw, req)
+
+	var scheme string
+
+	// Build redirect URI from request host
+	if req.URL.Scheme == "" {
+		if p.CookieSecure {
+			scheme = "https"
+		} else {
+			scheme = "http"
+		}
+	}
+
 	redirectURL := &url.URL{
-		Scheme: "https",
+		Scheme: scheme,
 		Host:   req.Host,
 		Path:   "/",
 	}


### PR DESCRIPTION
## Problem

When running in non https environment (such as in quickstart), the redirect generated by `/signout` is always `https`, so the links are broken.

## Solution

Use the `cookieSecure` option, as is done in `GetRedirectURL`: https://github.com/buzzfeed/sso/blob/master/internal/proxy/oauthproxy.go#L418
