### PR TITLE
sso-proxy: internal host should apply to redeem, /refresh, /validate, /profile

### DIFF
--- a/internal/proxy/options_test.go
+++ b/internal/proxy/options_test.go
@@ -71,8 +71,6 @@ func TestDefaultProviderApiSettings(t *testing.T) {
 		p.SignOutURL.String())
 	testutil.Equal(t, "https://www.example.com/redeem",
 		p.RedeemURL.String())
-	testutil.Equal(t, "https://www.example.com/redeem",
-		p.ProxyRedeemURL.String())
 	testutil.Equal(t, "https://www.example.com/validate",
 		p.ValidateURL.String())
 	testutil.Equal(t, "https://www.example.com/profile",
@@ -82,12 +80,12 @@ func TestDefaultProviderApiSettings(t *testing.T) {
 
 func TestProviderURLValidation(t *testing.T) {
 	testCases := []struct {
-		name                           string
-		providerURLString              string
-		proxyProviderURLString         string
-		expectedError                  string
-		expectedProxyProviderURLString string
-		expectedSignInURL              string
+		name                              string
+		providerURLString                 string
+		providerURLInternalString         string
+		expectedError                     string
+		expectedProviderURLInternalString string
+		expectedSignInURL                 string
 	}{
 		{
 			name:              "http scheme preserved",
@@ -100,15 +98,15 @@ func TestProviderURLValidation(t *testing.T) {
 			expectedSignInURL: "https://provider.example.com/sign_in",
 		},
 		{
-			name:                           "proxy provider url string based on providerURL",
-			providerURLString:              "https://provider.example.com",
-			expectedProxyProviderURLString: "https://provider.example.com",
+			name:                              "proxy provider url string based on providerURL",
+			providerURLString:                 "https://provider.example.com",
+			expectedProviderURLInternalString: "",
 		},
 		{
-			name:                           "proxy provider url string based on proxyProviderURL",
-			providerURLString:              "https://provider.example.com",
-			proxyProviderURLString:         "https://provider-internal.example.com",
-			expectedProxyProviderURLString: "https://provider-internal.example.com",
+			name:                              "proxy provider url string based on proxyProviderURL",
+			providerURLString:                 "https://provider.example.com",
+			providerURLInternalString:         "https://provider-internal.example.com",
+			expectedProviderURLInternalString: "https://provider-internal.example.com",
 		},
 		{
 			name:              "scheme required",
@@ -136,7 +134,7 @@ func TestProviderURLValidation(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			o := testOptions()
 			o.ProviderURLString = tc.providerURLString
-			o.ProxyProviderURLString = tc.proxyProviderURLString
+			o.ProviderURLInternalString = tc.providerURLInternalString
 			err := o.Validate()
 			if tc.expectedError != "" {
 				if err == nil {
@@ -148,8 +146,8 @@ func TestProviderURLValidation(t *testing.T) {
 			if tc.expectedSignInURL != "" {
 				testutil.Equal(t, o.provider.Data().SignInURL.String(), tc.expectedSignInURL)
 			}
-			if tc.expectedProxyProviderURLString != "" {
-				testutil.Equal(t, o.provider.Data().ProxyProviderURL.String(), tc.expectedProxyProviderURLString)
+			if tc.expectedProviderURLInternalString != "" {
+				testutil.Equal(t, o.provider.Data().ProviderURLInternal.String(), tc.expectedProviderURLInternalString)
 			}
 		})
 	}

--- a/internal/proxy/providers/provider_data.go
+++ b/internal/proxy/providers/provider_data.go
@@ -8,19 +8,18 @@ import (
 // ProviderData holds the fields associated with providers
 // necessary to implement the Provider interface.
 type ProviderData struct {
-	ProviderName     string
-	ProviderURL      *url.URL
-	ProxyProviderURL *url.URL
-	ClientID         string
-	ClientSecret     string
-	SignInURL        *url.URL
-	SignOutURL       *url.URL
-	RedeemURL        *url.URL
-	ProxyRedeemURL   *url.URL
-	RefreshURL       *url.URL
-	ProfileURL       *url.URL
-	ValidateURL      *url.URL
-	Scope            string
+	ProviderName        string
+	ProviderURL         *url.URL
+	ProviderURLInternal *url.URL
+	ClientID            string
+	ClientSecret        string
+	SignInURL           *url.URL
+	SignOutURL          *url.URL
+	RedeemURL           *url.URL
+	RefreshURL          *url.URL
+	ProfileURL          *url.URL
+	ValidateURL         *url.URL
+	Scope               string
 
 	SessionValidTTL    time.Duration
 	SessionLifetimeTTL time.Duration

--- a/quickstart/docker-compose.yml
+++ b/quickstart/docker-compose.yml
@@ -29,7 +29,7 @@ services:
 
       - UPSTREAM_CONFIGS=/sso/upstream_configs.yml
       - PROVIDER_URL=http://sso-auth.localtest.me
-      - PROXY_PROVIDER_URL=http://host.docker.internal
+      - PROVIDER_URL_INTERNAL=http://host.docker.internal
 
       # CLIENT_ID and CLIENT_SECRET must match sso-auth's PROXY_CLIENT_ID and
       # PROXY_CLIENT_SECRET configuration

--- a/quickstart/kubernetes/sso-proxy-deployment.yml
+++ b/quickstart/kubernetes/sso-proxy-deployment.yml
@@ -25,6 +25,8 @@ spec:
             value: /sso/upstream_configs.yml
           - name: PROVIDER_URL
             value: https://sso-auth.mydomain.com
+          - name: PROVIDER_URL_INTERNAL
+            value: http://sso-auth.sso.svc.cluster.local
           - name: CLIENT_ID
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
## Problem

Dan's [PR](https://github.com/buzzfeed/sso/pull/88) added the ability to have an optional 'internal' host defined that `proxy` will use to connect to `auth`. However, that internal host was only applied on `/redeem` requests. Other cases where `proxy` makes a request to `auth`, like `/refresh`, `/validate`, or `/profile` should also use this internal host if it is provided.

## Solution

If the optional `PROVIDER_URL_INTERNAL` is set, use that host to connect to `auth` for /redeem, /refresh, /validate, and /profile.

