### PR TITLE
docs: add a note that we do not support nested groups

### DIFF
--- a/docs/google_provider_setup.md
+++ b/docs/google_provider_setup.md
@@ -63,7 +63,7 @@ You'll add these credentials to `quickstart/env` as instructed in [the guide](qu
 ## 3. Set up a service account for Google Groups-based authorization
 
 If desired, `sso` can be configured to use Google Groups membership for authorization, only granting
-access to an upstream to users that are members of particular groups.
+access to an upstream to users that are members of particular groups. *Note*: We do not support nested group authentication at this time. Groups must be made up of email addresses  associated with individual's accounts. See [#133](https://github.com/buzzfeed/sso/issues/133).
 
 ### Create a service account
 

--- a/docs/sso_config.md
+++ b/docs/sso_config.md
@@ -30,7 +30,7 @@ For example, the following config would have the following environment variables
   * **to** is the cname of the proxied service (this tells sso proxy where to proxy requests that come in on the from field)
   * **type** declares the type of route to use, right now there is just *simple* and *rewrite*.
   * **options** are a set of options that can be added to your configuration.
-    * **allowed groups** optional list of authorized google groups that can access the service. If not specified, anyone within an email domain is allowed to access the service.
+    * **allowed groups** optional list of authorized google groups that can access the service. If not specified, anyone within an email domain is allowed to access the service. *Note*: We do not support nested group authentication at this time. Groups must be made up of email addresses associated with individual's accounts. See [#133](https://github.com/buzzfeed/sso/issues/133).
     * **skip_auth_regex** skips authentication for paths matching these regular expressions. NOTE: Use with extreme caution.
     * **header_overrides** overrides any heads set either by SSO proxy itself or upstream applications. Useful for modifying browser security headers.
     * **timeout** sets the amount of time that SSO Proxy will wait for the upstream to complete its request.


### PR DESCRIPTION
Make the documentation clear that we do not support nested groups in `allowed_groups`. 

In response to #133 