### PR TITLE
Add curl to image to help with Istio liveness checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,6 @@ RUN cd cmd/sso-proxy && go build -o /bin/sso-proxy
 # add static assets and copy binaries from build stage
 # =============================================================================
 FROM debian:stable-slim
-RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y ca-certificates curl && rm -rf /var/lib/apt/lists/*
 WORKDIR /sso
 COPY --from=build /bin/sso-* /bin/


### PR DESCRIPTION
## Problem

When SSO is deployed with Istio mutual TLS enabled, the normal liveness checks will not work i.e. these:

```
livenessProbe:
  httpGet:
    path: /ping
    port: 4180
    scheme: HTTP
readinessProbe:
  httpGet:
    path: /ping
    port: 4180
    scheme: HTTP
```

> If mutual TLS is enabled, http and tcp health checks from the kubelet will not work since the kubelet does not have Istio-issued certificates.

Further reading here: https://istio.io/help/faq/security/#k8s-health-checks

## Solution

The above link suggests using a liveness command, e.g. by installing `curl` and using that instead. `curl` is not currently available in the built image, so this PR adds it.

It would then be possible to use SSO in a cluster with Istio mutual TLS enabled, i.e. the checks can then be changed to
```
livenessProbe:
  exec:
    command:
      - curl
      - -f
      - http://localhost:4180/ping
readinessProbe:
  exec:
    command:
      - curl
      - -f
      - http://localhost:4180/ping
```