### PR TITLE
Cookie overflow fix

### DIFF
--- a/internal/pkg/sessions/cookie_store.go
+++ b/internal/pkg/sessions/cookie_store.go
@@ -16,8 +16,10 @@ import (
 
 const (
 	// CookieMaxLength controls the byte length where cookie spanning occurs
-	// See http://browsercookielimits.squawky.net/
-	CookieMaxLength = 4093
+	// See http://browsercookielimits.squawky.net/ for guidance, however in
+	// practice this needs to be set smaller than the limit due to the entire
+	// header string counting against the limit.
+	CookieMaxLength = 3840
 	// PrefixDelimiter should be unreserved and not used by any base64 encoding
 	PrefixDelimiter = "~"
 )

--- a/internal/pkg/sessions/cookie_store.go
+++ b/internal/pkg/sessions/cookie_store.go
@@ -1,6 +1,8 @@
 package sessions
 
 import (
+	"encoding/base64"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"net"
@@ -10,6 +12,14 @@ import (
 
 	"github.com/buzzfeed/sso/internal/pkg/aead"
 	log "github.com/buzzfeed/sso/internal/pkg/logging"
+)
+
+const (
+	// CookieMaxLength controls the byte length where cookie spanning occurs
+	// See http://browsercookielimits.squawky.net/
+	CookieMaxLength = 4093
+	// PrefixDelimiter should be unreserved and not used by any base64 encoding
+	PrefixDelimiter = "~"
 )
 
 // ErrInvalidSession is an error for invalid sessions.
@@ -79,7 +89,46 @@ func NewCookieStore(cookieName string, optFuncs ...func(*CookieStore) error) (*C
 	return c, nil
 }
 
-func (s *CookieStore) makeCookie(req *http.Request, name string, value string, expiration time.Duration, now time.Time) *http.Cookie {
+// cookieCount calculates the number of cookies needed if spanning at
+// the CookieMaxLength boundary.
+func cookieCount(size int) int {
+	return ((size - 1) / CookieMaxLength) + 1
+}
+
+// generatePrefix for the first cookie so that we know how many bytes were expected.
+// Users can clear cookies individually and we want to be able to detect that we're
+// in an invalid state and clear. It's also possible something could cause extra cookies
+// to be left over.
+func generatePrefix(size int) string {
+	rawPrefix := make([]byte, binary.MaxVarintLen64)
+	n := binary.PutUvarint(rawPrefix, uint64(size))
+	return base64.URLEncoding.EncodeToString(rawPrefix[:n]) + PrefixDelimiter
+}
+
+// parsePrefix for the first cookie so that we know how many bytes were expected.
+// Returns -1 if prefix is unparseable.
+func parsePrefix(cookieValue string) int {
+	segments := strings.Split(cookieValue, PrefixDelimiter)
+	if len(segments) <= 1 {
+		return -1
+	}
+	prefix := segments[0]
+	if prefix == "" {
+		return -1
+	}
+	rawPrefix, err := base64.URLEncoding.DecodeString(prefix)
+	if err != nil {
+		return -1
+	}
+	size, n := binary.Uvarint(rawPrefix)
+	if n != len(rawPrefix) {
+		// input was not fully consumed
+		return -1
+	}
+	return int(size)
+}
+
+func (s *CookieStore) makeCookies(req *http.Request, name string, value string, expiration time.Duration, now time.Time) []*http.Cookie {
 	logger := log.NewLogEntry()
 	domain := req.Host
 	if h, _, err := net.SplitHostPort(domain); err == nil {
@@ -92,35 +141,87 @@ func (s *CookieStore) makeCookie(req *http.Request, name string, value string, e
 		domain = s.CookieDomain
 	}
 
-	return &http.Cookie{
-		Name:     name,
-		Value:    value,
+	prefix := generatePrefix(len(value))
+	spannedValue := prefix + value
+
+	var cookies []*http.Cookie
+	chunk := make([]byte, CookieMaxLength)
+	reader := strings.NewReader(spannedValue)
+	for {
+		n, err := reader.Read(chunk)
+		if err != nil {
+			// TODO: figure out if this can happen
+			panic(err)
+		}
+		if n > 0 {
+			index := len(cookies)
+			cookies = append(cookies, &http.Cookie{
+				Name:     fmt.Sprintf("%s_%d", name, index),
+				Value:    string(chunk[:n]),
+				Path:     "/",
+				Domain:   domain,
+				HttpOnly: s.CookieHTTPOnly,
+				Secure:   s.CookieSecure,
+				Expires:  now.Add(expiration),
+			})
+		}
+		if n < CookieMaxLength {
+			break
+		}
+	}
+	// Clear the nearest overflow cookie
+	cookies = append(cookies, &http.Cookie{
+		Name:     fmt.Sprintf("%s_%d", name, len(cookies)),
+		Value:    "",
 		Path:     "/",
 		Domain:   domain,
 		HttpOnly: s.CookieHTTPOnly,
 		Secure:   s.CookieSecure,
 		Expires:  now.Add(expiration),
+	})
+	return cookies
+}
+
+func readSpannedCookies(cookies []*http.Cookie) (string, error) {
+	var sb strings.Builder
+	for i, cookie := range cookies {
+		if i == 0 {
+			segments := strings.Split(cookie.Value, PrefixDelimiter)
+			if len(segments) <= 1 {
+				return "", errors.New("missing size prefix")
+			}
+			sb.WriteString(segments[1])
+		} else {
+			sb.WriteString(cookie.Value)
+		}
+	}
+	return sb.String(), nil
+}
+
+func setCookies(rw http.ResponseWriter, cookies []*http.Cookie) {
+	for _, cookie := range cookies {
+		http.SetCookie(rw, cookie)
 	}
 }
 
 // makeSessionCookie constructs a session cookie given the request, an expiration time and the current time.
-func (s *CookieStore) makeSessionCookie(req *http.Request, value string, expiration time.Duration, now time.Time) *http.Cookie {
-	return s.makeCookie(req, s.Name, value, expiration, now)
+func (s *CookieStore) makeSessionCookies(req *http.Request, value string, expiration time.Duration, now time.Time) []*http.Cookie {
+	return s.makeCookies(req, s.Name, value, expiration, now)
 }
 
 // makeCSRFCookie creates a CSRF cookie given the request, an expiration time, and the current time.
-func (s *CookieStore) makeCSRFCookie(req *http.Request, value string, expiration time.Duration, now time.Time) *http.Cookie {
-	return s.makeCookie(req, s.CSRFCookieName, value, expiration, now)
+func (s *CookieStore) makeCSRFCookies(req *http.Request, value string, expiration time.Duration, now time.Time) []*http.Cookie {
+	return s.makeCookies(req, s.CSRFCookieName, value, expiration, now)
 }
 
 // ClearCSRF clears the CSRF cookie from the request
 func (s *CookieStore) ClearCSRF(rw http.ResponseWriter, req *http.Request) {
-	http.SetCookie(rw, s.makeCSRFCookie(req, "", time.Hour*-1, time.Now()))
+	setCookies(rw, s.makeCSRFCookies(req, "", time.Hour*-1, time.Now()))
 }
 
 // SetCSRF sets the CSRFCookie creates a CSRF cookie in a given request
 func (s *CookieStore) SetCSRF(rw http.ResponseWriter, req *http.Request, val string) {
-	http.SetCookie(rw, s.makeCSRFCookie(req, val, s.CookieExpire, time.Now()))
+	setCookies(rw, s.makeCSRFCookies(req, val, s.CookieExpire, time.Now()))
 }
 
 // GetCSRF gets the CSRFCookie creates a CSRF cookie in a given request
@@ -130,22 +231,40 @@ func (s *CookieStore) GetCSRF(req *http.Request) (*http.Cookie, error) {
 
 // ClearSession clears the session cookie from a request
 func (s *CookieStore) ClearSession(rw http.ResponseWriter, req *http.Request) {
-	http.SetCookie(rw, s.makeSessionCookie(req, "", time.Hour*-1, time.Now()))
+	setCookies(rw, s.makeSessionCookies(req, "", time.Hour*-1, time.Now()))
 }
 
-func (s *CookieStore) setSessionCookie(rw http.ResponseWriter, req *http.Request, val string) {
-	http.SetCookie(rw, s.makeSessionCookie(req, val, s.CookieExpire, time.Now()))
+func (s *CookieStore) setSessionCookies(rw http.ResponseWriter, req *http.Request, val string) {
+	setCookies(rw, s.makeSessionCookies(req, val, s.CookieExpire, time.Now()))
 }
 
 // LoadSession returns a SessionState from the cookie in the request.
 func (s *CookieStore) LoadSession(req *http.Request) (*SessionState, error) {
 	logger := log.NewLogEntry()
-	c, err := req.Cookie(s.Name)
+	firstCookie, err := req.Cookie(fmt.Sprintf("%s_0", s.Name))
 	if err != nil {
 		// always http.ErrNoCookie
 		return nil, err
 	}
-	session, err := UnmarshalSession(c.Value, s.CookieCipher)
+	byteSize := parsePrefix(firstCookie.Value)
+	if byteSize < 0 {
+		return nil, errors.New("could not parse prefixed cookie")
+	}
+	cookieCount := cookieCount(byteSize)
+	cookies := make([]*http.Cookie, 0)
+	for i := 0; i < cookieCount; i++ {
+		cookie, err := req.Cookie(fmt.Sprintf("%s_%d", s.Name, i))
+		if err != nil {
+			// always http.ErrNoCookie
+			return nil, err
+		}
+		cookies = append(cookies, cookie)
+	}
+	value, err := readSpannedCookies(cookies)
+	if err != nil {
+		return nil, err
+	}
+	session, err := UnmarshalSession(value, s.CookieCipher)
 	if err != nil {
 		logger.WithRequestHost(req.Host).WithError(err).Error("error unmarshaling session")
 		return nil, ErrInvalidSession
@@ -160,6 +279,6 @@ func (s *CookieStore) SaveSession(rw http.ResponseWriter, req *http.Request, ses
 		return err
 	}
 
-	s.setSessionCookie(rw, req, value)
+	s.setSessionCookies(rw, req, value)
 	return nil
 }

--- a/internal/pkg/sessions/cookie_store_test.go
+++ b/internal/pkg/sessions/cookie_store_test.go
@@ -123,11 +123,11 @@ func TestCookiePrefix(t *testing.T) {
 	}{
 		{"zero bytes", 0, "AA==~"},
 		{"one byte", 1, "AQ==~"},
-		{"max single cookie bytes", CookieMaxLength, "gB4=~"},
-		{"one byte overflow", CookieMaxLength + 1, "gR4=~"},
-		{"max two cookie bytes", CookieMaxLength * 2, "gDw=~"},
-		{"max two cookie bytes with overflow", CookieMaxLength*2 + 1, "gTw=~"},
-		{"a lot of bytes", CookieMaxLength * 600, "gNCMAQ==~"},
+		{"max single cookie bytes", 3840, "gB4=~"},
+		{"one byte overflow", 3840 + 1, "gR4=~"},
+		{"max two cookie bytes", 3840 * 2, "gDw=~"},
+		{"max two cookie bytes with overflow", 3840*2 + 1, "gTw=~"},
+		{"a lot of bytes", 3840 * 700, "gIikAQ==~"},
 	}
 
 	for _, tc := range testCases {

--- a/internal/pkg/sessions/cookie_store_test.go
+++ b/internal/pkg/sessions/cookie_store_test.go
@@ -123,11 +123,11 @@ func TestCookiePrefix(t *testing.T) {
 	}{
 		{"zero bytes", 0, "AA==~"},
 		{"one byte", 1, "AQ==~"},
-		{"max single cookie bytes", CookieMaxLength, "_R8=~"},
-		{"one byte overflow", CookieMaxLength + 1, "_h8=~"},
-		{"max two cookie bytes", CookieMaxLength * 2, "-j8=~"},
-		{"max two cookie bytes with overflow", CookieMaxLength*2 + 1, "-z8=~"},
-		{"a lot of bytes", CookieMaxLength * 600, "-PGVAQ==~"},
+		{"max single cookie bytes", CookieMaxLength, "gB4=~"},
+		{"one byte overflow", CookieMaxLength + 1, "gR4=~"},
+		{"max two cookie bytes", CookieMaxLength * 2, "gDw=~"},
+		{"max two cookie bytes with overflow", CookieMaxLength*2 + 1, "gTw=~"},
+		{"a lot of bytes", CookieMaxLength * 600, "gNCMAQ==~"},
 	}
 
 	for _, tc := range testCases {

--- a/internal/pkg/sessions/cookie_store_test.go
+++ b/internal/pkg/sessions/cookie_store_test.go
@@ -93,9 +93,72 @@ func TestNewSession(t *testing.T) {
 	}
 }
 
+func TestCookieCount(t *testing.T) {
+	testCases := []struct {
+		name          string
+		size          int
+		expectedCount int
+	}{
+		{"zero bytes", 0, 1},
+		{"one byte", 1, 1},
+		{"max single cookie bytes", CookieMaxLength, 1},
+		{"one byte overflow", CookieMaxLength + 1, 2},
+		{"max two cookie bytes", CookieMaxLength * 2, 2},
+		{"max two cookie bytes with overflow", CookieMaxLength*2 + 1, 3},
+		{"a lot of bytes", CookieMaxLength * 600, 600},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			testutil.Equal(t, tc.expectedCount, cookieCount(tc.size))
+		})
+	}
+}
+
+func TestCookiePrefix(t *testing.T) {
+	testCases := []struct {
+		name           string
+		size           int
+		expectedPrefix string
+	}{
+		{"zero bytes", 0, "AA==~"},
+		{"one byte", 1, "AQ==~"},
+		{"max single cookie bytes", CookieMaxLength, "_R8=~"},
+		{"one byte overflow", CookieMaxLength + 1, "_h8=~"},
+		{"max two cookie bytes", CookieMaxLength * 2, "-j8=~"},
+		{"max two cookie bytes with overflow", CookieMaxLength*2 + 1, "-z8=~"},
+		{"a lot of bytes", CookieMaxLength * 600, "-PGVAQ==~"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			testutil.Equal(t, tc.expectedPrefix, generatePrefix(tc.size))
+			testutil.Equal(t, tc.size, parsePrefix(generatePrefix(tc.size)))
+		})
+	}
+
+	errorCases := []struct {
+		name  string
+		input string
+	}{
+		{"empty string", ""},
+		{"no delimeter", "bogus"},
+		{"empty prefix", PrefixDelimiter + "bogus"},
+		{"invalid base64", "!@#$%^" + PrefixDelimiter},
+		{"unconsumed bytes", "AAA=" + PrefixDelimiter},
+	}
+
+	for _, tc := range errorCases {
+		t.Run(tc.name, func(t *testing.T) {
+			testutil.Equal(t, -1, parsePrefix(tc.input))
+		})
+	}
+}
+
 func TestMakeSessionCookie(t *testing.T) {
 	now := time.Now()
 	cookieValue := "cookieValue"
+	spannedValue := fmt.Sprintf("Cw==~%s", cookieValue)
 	expiration := time.Hour
 	cookieName := "cookieName"
 	testCases := []struct {
@@ -106,8 +169,8 @@ func TestMakeSessionCookie(t *testing.T) {
 		{
 			name: "default cookie domain",
 			expectedCookie: &http.Cookie{
-				Name:     cookieName,
-				Value:    cookieValue,
+				Name:     cookieName + "_0",
+				Value:    spannedValue,
 				Path:     "/",
 				Domain:   "www.example.com",
 				HttpOnly: true,
@@ -124,8 +187,8 @@ func TestMakeSessionCookie(t *testing.T) {
 				},
 			},
 			expectedCookie: &http.Cookie{
-				Name:     cookieName,
-				Value:    cookieValue,
+				Name:     cookieName + "_0",
+				Value:    spannedValue,
 				Path:     "/",
 				Domain:   "buzzfeed.com",
 				HttpOnly: true,
@@ -140,8 +203,8 @@ func TestMakeSessionCookie(t *testing.T) {
 			session, err := NewCookieStore(cookieName, tc.optFuncs...)
 			testutil.Ok(t, err)
 			req := httptest.NewRequest("GET", "http://www.example.com", nil)
-			cookie := session.makeSessionCookie(req, cookieValue, expiration, now)
-			testutil.Equal(t, cookie, tc.expectedCookie)
+			cookies := session.makeSessionCookies(req, cookieValue, expiration, now)
+			testutil.Equal(t, tc.expectedCookie, cookies[0])
 		})
 	}
 }
@@ -149,6 +212,7 @@ func TestMakeSessionCookie(t *testing.T) {
 func TestMakeSessionCSRFCookie(t *testing.T) {
 	now := time.Now()
 	cookieValue := "cookieValue"
+	spannedValue := fmt.Sprintf("Cw==~%s", cookieValue)
 	expiration := time.Hour
 	cookieName := "cookieName"
 	csrfName := "cookieName_csrf"
@@ -161,8 +225,8 @@ func TestMakeSessionCSRFCookie(t *testing.T) {
 		{
 			name: "default cookie domain",
 			expectedCookie: &http.Cookie{
-				Name:     csrfName,
-				Value:    cookieValue,
+				Name:     csrfName + "_0",
+				Value:    spannedValue,
 				Path:     "/",
 				Domain:   "www.example.com",
 				HttpOnly: true,
@@ -179,8 +243,8 @@ func TestMakeSessionCSRFCookie(t *testing.T) {
 				},
 			},
 			expectedCookie: &http.Cookie{
-				Name:     csrfName,
-				Value:    cookieValue,
+				Name:     csrfName + "_0",
+				Value:    spannedValue,
 				Path:     "/",
 				Domain:   "buzzfeed.com",
 				HttpOnly: true,
@@ -195,14 +259,15 @@ func TestMakeSessionCSRFCookie(t *testing.T) {
 			session, err := NewCookieStore(cookieName, tc.optFuncs...)
 			testutil.Ok(t, err)
 			req := httptest.NewRequest("GET", "http://www.example.com", nil)
-			cookie := session.makeCSRFCookie(req, cookieValue, expiration, now)
-			testutil.Equal(t, tc.expectedCookie, cookie)
+			cookies := session.makeCSRFCookies(req, cookieValue, expiration, now)
+			testutil.Equal(t, tc.expectedCookie, cookies[0])
 		})
 	}
 }
 
 func TestSetSessionCookie(t *testing.T) {
 	cookieValue := "cookieValue"
+	spannedValue := fmt.Sprintf("Cw==~%s", cookieValue)
 	cookieName := "cookieName"
 
 	t.Run("set session cookie test", func(t *testing.T) {
@@ -210,12 +275,12 @@ func TestSetSessionCookie(t *testing.T) {
 		testutil.Ok(t, err)
 		req := httptest.NewRequest("GET", "http://www.example.com", nil)
 		rw := httptest.NewRecorder()
-		session.setSessionCookie(rw, req, cookieValue)
+		session.setSessionCookies(rw, req, cookieValue)
 		var found bool
 		for _, cookie := range rw.Result().Cookies() {
-			if cookie.Name == cookieName {
+			if cookie.Name == fmt.Sprintf("%s_0", cookieName) {
 				found = true
-				testutil.Equal(t, cookieValue, cookie.Value)
+				testutil.Equal(t, spannedValue, cookie.Value)
 				testutil.Assert(t, cookie.Expires.After(time.Now()), "cookie expires after now")
 			}
 		}
@@ -224,6 +289,7 @@ func TestSetSessionCookie(t *testing.T) {
 }
 func TestSetCSRFSessionCookie(t *testing.T) {
 	cookieValue := "cookieValue"
+	spannedValue := fmt.Sprintf("Cw==~%s", cookieValue)
 	cookieName := "cookieName"
 
 	t.Run("set csrf cookie test", func(t *testing.T) {
@@ -234,9 +300,9 @@ func TestSetCSRFSessionCookie(t *testing.T) {
 		session.SetCSRF(rw, req, cookieValue)
 		var found bool
 		for _, cookie := range rw.Result().Cookies() {
-			if cookie.Name == fmt.Sprintf("%s_csrf", cookieName) {
+			if cookie.Name == fmt.Sprintf("%s_csrf_0", cookieName) {
 				found = true
-				testutil.Equal(t, cookieValue, cookie.Value)
+				testutil.Equal(t, spannedValue, cookie.Value)
 				testutil.Assert(t, cookie.Expires.After(time.Now()), "cookie expires after now")
 			}
 		}
@@ -248,23 +314,32 @@ func TestClearSessionCookie(t *testing.T) {
 	cookieValue := "cookieValue"
 	cookieName := "cookieName"
 
-	t.Run("set session cookie test", func(t *testing.T) {
+	t.Run("clear session cookie test", func(t *testing.T) {
 		session, err := NewCookieStore(cookieName)
 		testutil.Ok(t, err)
 		req := httptest.NewRequest("GET", "http://www.example.com", nil)
-		req.AddCookie(session.makeSessionCookie(req, cookieValue, time.Hour, time.Now()))
+		cookies := session.makeSessionCookies(req, cookieValue, time.Hour, time.Now())
+		for _, cookie := range cookies {
+			req.AddCookie(cookie)
+		}
 
 		rw := httptest.NewRecorder()
 		session.ClearSession(rw, req)
-		var found bool
+		var foundPrimary bool
+		var foundOverflow bool
 		for _, cookie := range rw.Result().Cookies() {
-			if cookie.Name == cookieName {
-				found = true
+			if cookie.Name == fmt.Sprintf("%s_0", cookieName) {
+				foundPrimary = true
+				testutil.Equal(t, "AA==~", cookie.Value) // zero byte prefix followed by zero bytes
+				testutil.Assert(t, cookie.Expires.Before(time.Now()), "cookie expires before now")
+			} else if cookie.Name == fmt.Sprintf("%s_1", cookieName) {
+				foundOverflow = true
 				testutil.Equal(t, "", cookie.Value)
 				testutil.Assert(t, cookie.Expires.Before(time.Now()), "cookie expires before now")
 			}
 		}
-		testutil.Assert(t, found, "cookie in header")
+		testutil.Assert(t, foundPrimary, "primary cookie present in header")
+		testutil.Assert(t, foundOverflow, "overflow cookie present in header")
 	})
 }
 
@@ -276,19 +351,28 @@ func TestClearCSRFSessionCookie(t *testing.T) {
 		session, err := NewCookieStore(cookieName)
 		testutil.Ok(t, err)
 		req := httptest.NewRequest("GET", "http://www.example.com", nil)
-		req.AddCookie(session.makeCSRFCookie(req, cookieValue, time.Hour, time.Now()))
+		cookies := session.makeCSRFCookies(req, cookieValue, time.Hour, time.Now())
+		for _, cookie := range cookies {
+			req.AddCookie(cookie)
+		}
 
 		rw := httptest.NewRecorder()
 		session.ClearCSRF(rw, req)
-		var found bool
+		var foundPrimary bool
+		var foundOverflow bool
 		for _, cookie := range rw.Result().Cookies() {
-			if cookie.Name == fmt.Sprintf("%s_csrf", cookieName) {
-				found = true
+			if cookie.Name == fmt.Sprintf("%s_csrf_0", cookieName) {
+				foundPrimary = true
+				testutil.Equal(t, "AA==~", cookie.Value) // zero byte prefix followed by zero bytes
+				testutil.Assert(t, cookie.Expires.Before(time.Now()), "cookie expires before now")
+			} else if cookie.Name == fmt.Sprintf("%s_csrf_1", cookieName) {
+				foundOverflow = true
 				testutil.Equal(t, "", cookie.Value)
 				testutil.Assert(t, cookie.Expires.Before(time.Now()), "cookie expires before now")
 			}
 		}
-		testutil.Assert(t, found, "cookie in header")
+		testutil.Assert(t, foundPrimary, "primary csrf cookie present in header")
+		testutil.Assert(t, foundOverflow, "overflow csrf cookie present in header")
 	})
 }
 
@@ -313,7 +397,10 @@ func TestLoadCookiedSession(t *testing.T) {
 			setupCookies: func(t *testing.T, req *http.Request, s *CookieStore, sessionState *SessionState) {
 				value, err := MarshalSession(sessionState, s.CookieCipher)
 				testutil.Ok(t, err)
-				req.AddCookie(s.makeSessionCookie(req, value, time.Hour, time.Now()))
+				cookies := s.makeSessionCookies(req, value, time.Hour, time.Now())
+				for _, cookie := range cookies {
+					req.AddCookie(cookie)
+				}
 			},
 			sessionState: &SessionState{
 				Email:        "example@email.com",
@@ -326,7 +413,10 @@ func TestLoadCookiedSession(t *testing.T) {
 			optFuncs: []func(*CookieStore) error{CreateMiscreantCookieCipher(testEncodedCookieSecret)},
 			setupCookies: func(t *testing.T, req *http.Request, s *CookieStore, sessionState *SessionState) {
 				value := "574b776a7c934d6b9fc42ec63a389f79"
-				req.AddCookie(s.makeSessionCookie(req, value, time.Hour, time.Now()))
+				cookies := s.makeSessionCookies(req, value, time.Hour, time.Now())
+				for _, cookie := range cookies {
+					req.AddCookie(cookie)
+				}
 			},
 			expectedError: ErrInvalidSession,
 		},


### PR DESCRIPTION
## Problem

Azure AD (#118) produces massive 3kb tokens. Storing them directly inside cookies produces around 5kb of cookie after compression (#95) and encryption. Browsers typically limit sites to only 4096 bytes (or in some cases, very slightly less) per cookie, with about 110 bytes or so being used up by the cookie name and various attributes. So in practice, you can only store about 3986ish bytes per cookie, which the Azure AD provider goes way past.

## Solution

Since we don't want to maintain server-side state, I've implemented a cookie store that automatically spans the data being stored across multiple cookies when needed, using a byte length prefix in the first cookie. It uses `~` as the delimiter between the cookie length prefix and the spanned cookie value since it's not used by any base64 encoding and also not escaped in URLs, HTTP headers, or HTML forms. The prefix is simply a base64 encoded binary serialization of the integer byte length.

## Notes

The prefix length isn't signed or encrypted and could be altered by a malicious client, however altering it should't do anything beneficial. It should just result in an error (all error conditions covered in test cases).