### PR TITLE
sso_proxy: add reset deadline for http transports

### DIFF
--- a/internal/proxy/oauthproxy_test.go
+++ b/internal/proxy/oauthproxy_test.go
@@ -454,7 +454,10 @@ func TestRoundTrip(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			req := httptest.NewRequest("GET", tc.url, nil)
-			ut := newUpstreamTransport(false)
+			ut := &upstreamTransport{
+				insecureSkipVerify: false,
+				resetDeadline:      time.Duration(1) * time.Minute,
+			}
 			resp, err := ut.RoundTrip(req)
 			if err == nil && tc.expectedError {
 				t.Errorf("expected error but error was nil")

--- a/internal/proxy/proxy_config.go
+++ b/internal/proxy/proxy_config.go
@@ -56,6 +56,7 @@ type UpstreamConfig struct {
 	PreserveHost          bool
 	HMACAuth              hmacauth.HmacAuth
 	Timeout               time.Duration
+	ResetDeadline         time.Duration
 	FlushInterval         time.Duration
 	HeaderOverrides       map[string]string
 	SkipRequestSigning    bool
@@ -85,6 +86,7 @@ type OptionsConfig struct {
 	TLSSkipVerify      bool              `yaml:"tls_skip_verify"`
 	PreserveHost       bool              `yaml:"preserve_host"`
 	Timeout            time.Duration     `yaml:"timeout"`
+	ResetDeadline      time.Duration     `yaml:"reset_deadline"`
 	FlushInterval      time.Duration     `yaml:"flush_interval"`
 	SkipRequestSigning bool              `yaml:"skip_request_signing"`
 }
@@ -382,6 +384,7 @@ func parseOptionsConfig(proxy *UpstreamConfig, defaultOpts *OptionsConfig) error
 
 	proxy.AllowedGroups = dst.AllowedGroups
 	proxy.Timeout = dst.Timeout
+	proxy.ResetDeadline = dst.ResetDeadline
 	proxy.FlushInterval = dst.FlushInterval
 	proxy.HeaderOverrides = dst.HeaderOverrides
 	proxy.TLSSkipVerify = dst.TLSSkipVerify


### PR DESCRIPTION
## Problem

In dynamic routing environments, upstreams may move IP addresses and intermediate gateways may not gracefully terminate those TCP connections. This is particularly problematic in environments were upstreams may exist on shared infrastructure such as AWS Application Load Balancers.

## Solution

We need to provide a reset deadline for these TCP connections to rotate them, even if the TCP connections are still active. Unfortunately, to the best of my knowledge, the Go standard library does not provide such dials to rotate active TCP connections after some deadline period.

We implement this logic by lazily rotating the entire HTTP Transport object after deadline intervals expire.

This will create some extra garbage but this should be nominal in most environments.
