### PR TITLE
sso-proxy: clear csrf token further down the request flow

### DIFF
--- a/internal/proxy/oauthproxy.go
+++ b/internal/proxy/oauthproxy.go
@@ -754,7 +754,6 @@ func (p *OAuthProxy) OAuthCallback(rw http.ResponseWriter, req *http.Request) {
 		p.ErrorPage(rw, req, http.StatusBadRequest, "Bad Request", err.Error())
 		return
 	}
-	p.csrfStore.ClearCSRF(rw, req)
 
 	encryptedCSRF := c.Value
 	csrfParameter := &StateParameter{}
@@ -841,6 +840,9 @@ func (p *OAuthProxy) OAuthCallback(rw http.ResponseWriter, req *http.Request) {
 		p.ErrorPage(rw, req, http.StatusInternalServerError, "Internal Error", "Internal Error")
 		return
 	}
+
+	// Now that we know the request and user is valid, clear the CSRF token
+	p.csrfStore.ClearCSRF(rw, req)
 
 	// This is the redirect back to the original requested application
 	http.Redirect(rw, req, stateParameter.RedirectURI, http.StatusFound)


### PR DESCRIPTION
## Problem

Currently, upon refresh of the `Group membership required` error page it changes to a `http: named cookie not present` error page. Related issue: https://github.com/buzzfeed/sso/issues/94

## Solution
We currently remove the CSRF token from the request after getting and assigning it to a new variable. If, further down the flow the request is found to be invalid for some reason (in this case, the user not being in the required groups) then the relevant error page is given. Upon refresh it tries to grab the CSRF token again however it's no longer part of the request, and so it errors in a less helpful and informative way.

Instead, only clear the CSRF token once we know the request has passed the various checks


