### PR TITLE
sso: send access token on group information query

### DIFF
--- a/internal/auth/providers/google.go
+++ b/internal/auth/providers/google.go
@@ -332,7 +332,7 @@ func (p *GoogleProvider) PopulateMembers(group string) (groups.MemberSet, error)
 
 // ValidateGroupMembership takes in an email and the allowed groups and returns the groups that the email is part of in that list.
 // If `allGroups` is an empty list, returns an empty list.
-func (p *GoogleProvider) ValidateGroupMembership(email string, allGroups []string) ([]string, error) {
+func (p *GoogleProvider) ValidateGroupMembership(email string, allGroups []string, _ string) ([]string, error) {
 	logger := log.NewLogEntry()
 
 	groups := []string{}

--- a/internal/auth/providers/google_test.go
+++ b/internal/auth/providers/google_test.go
@@ -392,7 +392,7 @@ func TestValidateGroupMembers(t *testing.T) {
 				GroupsCache:  &groups.MockCache{ListMembershipsFunc: tc.listMembershipsFunc, Refreshed: true},
 			}
 
-			groups, err := p.ValidateGroupMembership("email", tc.inputAllowedGroups)
+			groups, err := p.ValidateGroupMembership("email", tc.inputAllowedGroups, "accessToken")
 
 			if err != nil {
 				if tc.expectedErrorString != err.Error() {

--- a/internal/auth/providers/provider_default.go
+++ b/internal/auth/providers/provider_default.go
@@ -133,7 +133,7 @@ func (p *ProviderData) Revoke(s *sessions.SessionState) error {
 }
 
 // ValidateGroupMembership returns an ErrNotImplemented.
-func (p *ProviderData) ValidateGroupMembership(string, []string) ([]string, error) {
+func (p *ProviderData) ValidateGroupMembership(string, []string, string) ([]string, error) {
 	return nil, ErrNotImplemented
 }
 

--- a/internal/auth/providers/providers.go
+++ b/internal/auth/providers/providers.go
@@ -39,7 +39,7 @@ type Provider interface {
 	ValidateSessionState(*sessions.SessionState) bool
 	GetSignInURL(redirectURI, finalRedirect string) string
 	RefreshSessionIfNeeded(*sessions.SessionState) (bool, error)
-	ValidateGroupMembership(string, []string) ([]string, error)
+	ValidateGroupMembership(string, []string, string) ([]string, error)
 	Revoke(*sessions.SessionState) error
 	RefreshAccessToken(string) (string, time.Duration, error)
 	Stop()

--- a/internal/auth/providers/singleflight_middleware.go
+++ b/internal/auth/providers/singleflight_middleware.go
@@ -120,11 +120,11 @@ func (p *SingleFlightProvider) RefreshSessionIfNeeded(s *sessions.SessionState) 
 }
 
 // ValidateGroupMembership wraps the provider's GroupsResource function in a single flight call.
-func (p *SingleFlightProvider) ValidateGroupMembership(email string, allowedGroups []string) ([]string, error) {
+func (p *SingleFlightProvider) ValidateGroupMembership(email string, allowedGroups []string, accessToken string) ([]string, error) {
 	sort.Strings(allowedGroups)
 	response, err := p.do("ValidateGroupMembership", fmt.Sprintf("%s:%s", email, strings.Join(allowedGroups, ",")),
 		func() (interface{}, error) {
-			return p.provider.ValidateGroupMembership(email, allowedGroups)
+			return p.provider.ValidateGroupMembership(email, allowedGroups, accessToken)
 		})
 	if err != nil {
 		return nil, err

--- a/internal/auth/providers/test_provider.go
+++ b/internal/auth/providers/test_provider.go
@@ -76,7 +76,7 @@ func (tp *TestProvider) Revoke(*sessions.SessionState) error {
 }
 
 // ValidateGroupMembership returns the mock provider's GroupsError if not nil, or the Groups field value.
-func (tp *TestProvider) ValidateGroupMembership(string, []string) ([]string, error) {
+func (tp *TestProvider) ValidateGroupMembership(string, []string, string) ([]string, error) {
 	return tp.Groups, tp.GroupsError
 }
 

--- a/internal/proxy/oauthproxy.go
+++ b/internal/proxy/oauthproxy.go
@@ -810,7 +810,7 @@ func (p *OAuthProxy) OAuthCallback(rw http.ResponseWriter, req *http.Request) {
 	}
 	allowedGroups := route.upstreamConfig.AllowedGroups
 
-	inGroups, validGroup, err := p.provider.ValidateGroup(session.Email, allowedGroups)
+	inGroups, validGroup, err := p.provider.ValidateGroup(session.Email, allowedGroups, session.AccessToken)
 	if err != nil {
 		tags = append(tags, "error:user_group_failed")
 		p.StatsdClient.Incr("provider_error", tags, 1.0)

--- a/internal/proxy/providers/providers.go
+++ b/internal/proxy/providers/providers.go
@@ -11,8 +11,8 @@ import (
 type Provider interface {
 	Data() *ProviderData
 	Redeem(string, string) (*sessions.SessionState, error)
-	ValidateGroup(string, []string) ([]string, bool, error)
-	UserGroups(string, []string) ([]string, error)
+	ValidateGroup(string, []string, string) ([]string, bool, error)
+	UserGroups(string, []string, string) ([]string, error)
 	ValidateSessionState(*sessions.SessionState, []string) bool
 	GetSignInURL(redirectURL *url.URL, finalRedirect string) *url.URL
 	GetSignOutURL(redirectURL *url.URL) *url.URL

--- a/internal/proxy/providers/singleflight_middleware.go
+++ b/internal/proxy/providers/singleflight_middleware.go
@@ -71,16 +71,16 @@ func (p *SingleFlightProvider) Redeem(redirectURL, code string) (*sessions.Sessi
 }
 
 // ValidateGroup takes an email, allowedGroups, and userGroups and passes it to the provider's ValidateGroup function and returns the response
-func (p *SingleFlightProvider) ValidateGroup(email string, allowedGroups []string) ([]string, bool, error) {
-	return p.provider.ValidateGroup(email, allowedGroups)
+func (p *SingleFlightProvider) ValidateGroup(email string, allowedGroups []string, accessToken string) ([]string, bool, error) {
+	return p.provider.ValidateGroup(email, allowedGroups, accessToken)
 }
 
 // UserGroups takes an email and passes it to the provider's UserGroups function and returns the response
-func (p *SingleFlightProvider) UserGroups(email string, groups []string) ([]string, error) {
+func (p *SingleFlightProvider) UserGroups(email string, groups []string, accessToken string) ([]string, error) {
 	// sort the groups so that other requests may be able to use the cached request
 	sort.Strings(groups)
 	response, err := p.do("UserGroups", fmt.Sprintf("%s:%s", email, strings.Join(groups, ",")), func() (interface{}, error) {
-		return p.provider.UserGroups(email, groups)
+		return p.provider.UserGroups(email, groups, accessToken)
 	})
 	if err != nil {
 		return nil, err

--- a/internal/proxy/providers/sso_test.go
+++ b/internal/proxy/providers/sso_test.go
@@ -199,7 +199,7 @@ func TestSSOProviderGroups(t *testing.T) {
 			}
 			p.ProfileURL, server = newTestServer(profileStatus, body)
 			defer server.Close()
-			inGroups, valid, err := p.ValidateGroup(tc.Email, tc.ProxyGroupIds)
+			inGroups, valid, err := p.ValidateGroup(tc.Email, tc.ProxyGroupIds, "accessToken")
 			testutil.Equal(t, tc.ExpectError, err)
 			if err == nil {
 				testutil.Equal(t, tc.ExpectedValid, valid)

--- a/internal/proxy/providers/test_provider.go
+++ b/internal/proxy/providers/test_provider.go
@@ -11,8 +11,8 @@ type TestProvider struct {
 	RefreshSessionFunc  func(*sessions.SessionState, []string) (bool, error)
 	ValidateSessionFunc func(*sessions.SessionState, []string) bool
 	RedeemFunc          func(string, string) (*sessions.SessionState, error)
-	UserGroupsFunc      func(string, []string) ([]string, error)
-	ValidateGroupsFunc  func(string, []string) ([]string, bool, error)
+	UserGroupsFunc      func(string, []string, string) ([]string, error)
+	ValidateGroupsFunc  func(string, []string, string) ([]string, bool, error)
 	*ProviderData
 }
 
@@ -62,13 +62,13 @@ func (tp *TestProvider) RefreshSession(s *sessions.SessionState, g []string) (bo
 }
 
 // UserGroups mocks the UserGroups function
-func (tp *TestProvider) UserGroups(email string, groups []string) ([]string, error) {
-	return tp.UserGroupsFunc(email, groups)
+func (tp *TestProvider) UserGroups(email string, groups []string, accessToken string) ([]string, error) {
+	return tp.UserGroupsFunc(email, groups, accessToken)
 }
 
 // ValidateGroup mocks the ValidateGroup function
-func (tp *TestProvider) ValidateGroup(email string, groups []string) ([]string, bool, error) {
-	return tp.ValidateGroupsFunc(email, groups)
+func (tp *TestProvider) ValidateGroup(email string, groups []string, accessToken string) ([]string, bool, error) {
+	return tp.ValidateGroupsFunc(email, groups, accessToken)
 }
 
 // GetSignOutURL mocks GetSignOutURL function


### PR DESCRIPTION
## Problem

Not all identity providers provide the same API for access groups. This is especially true for Google which has a rather strange mechanism for fetching group information. 

Most identity providers, including Okta, require an individuals access token in order to query information about their groups. However, our abstractions now do not consider this and don't allow for this case.

## Solution

We pass on the access token now for all identity providers, even if not all identity providers (like Google) require it. This will prove useful and necessary when we get further along for adding access for Okta as an identity provider, which does require it.