### PR TITLE
pkg/logging: resolve timestamp bug

### DIFF
--- a/internal/pkg/logging/logging.go
+++ b/internal/pkg/logging/logging.go
@@ -12,7 +12,7 @@ var serviceName = "sso"
 
 func init() {
 	logrus.SetOutput(os.Stdout)
-	logrus.SetFormatter(&logrus.JSONFormatter{TimestampFormat: "2006-01-02 15:04:05.123"})
+	logrus.SetFormatter(&logrus.JSONFormatter{TimestampFormat: "2006-01-02 15:04:05.000"})
 }
 
 // SetServiceName configures the service name to log with each LogEntry.


### PR DESCRIPTION
## Problem

Our timestamp formatting is incorrect in our logging package. This results in a comically incorrect microsecond time being logged.

In `15:04:05.123`, `1`,`2`,`3` are identifiers being parsed as month, day, and hour respectively.

Fixes https://github.com/buzzfeed/sso/issues/176.

🤦‍♂️ 