### PR TITLE
proxy/request signers: request signers should also sign access token

### DIFF
--- a/internal/proxy/oauthproxy.go
+++ b/internal/proxy/oauthproxy.go
@@ -39,6 +39,7 @@ var SignatureHeaders = []string{
 	"X-Forwarded-User",
 	"X-Forwarded-Email",
 	"X-Forwarded-Groups",
+	"X-Forwarded-Access-Token",
 	"Cookie",
 }
 

--- a/internal/proxy/request_signer.go
+++ b/internal/proxy/request_signer.go
@@ -27,6 +27,7 @@ var signedHeaders = []string{
 	"X-Forwarded-User",
 	"X-Forwarded-Email",
 	"X-Forwarded-Groups",
+	"X-Forwarded-Access-Token",
 	"Cookie",
 }
 


### PR DESCRIPTION
## Problem

We received a security report that request signatures do not sign access tokens if the proxy is configured to forward them. These access tokens should be signed by our various signature methods so upstreams can be ensured that these tokens have not tampered via a MITM attack.
