### PR TITLE
Extend timeouts

### DIFF
--- a/internal/proxy/oauthproxy.go
+++ b/internal/proxy/oauthproxy.go
@@ -185,8 +185,8 @@ func (t *upstreamTransport) getTransport() *http.Transport {
 		t.transport = &http.Transport{
 			Proxy: http.ProxyFromEnvironment,
 			DialContext: (&net.Dialer{
-				Timeout:   30 * time.Second,
-				KeepAlive: 30 * time.Second,
+				Timeout:   300 * time.Second,
+				KeepAlive: 300 * time.Second,
 				DualStack: true,
 			}).DialContext,
 			MaxIdleConns:          100,
@@ -216,6 +216,7 @@ func NewReverseProxy(to *url.URL, config *UpstreamConfig) *httputil.ReverseProxy
 			req.Host = to.Host
 		}
 	}
+	proxy.FlushInterval = 100 * time.Millisecond
 	return proxy
 }
 


### PR DESCRIPTION
We're using SSO proxy to sit in the middle of another auth component that blocks waiting for authentication to complete. We need a long timeout to allow the user to finish the authentication flow that SSO is mediating. The timeout needs to at least get us past p99 time-to-complete-authentication and 5 minutes seems to be approximately the sweet spot.
