### PR TITLE
Auth/multi providers

### DIFF
--- a/cmd/sso-auth/main.go
+++ b/cmd/sso-auth/main.go
@@ -41,7 +41,13 @@ func main() {
 		return nil
 	}
 
-	authenticator, err := auth.NewAuthenticator(opts, emailValidator, auth.AssignProvider(opts), auth.SetCookieStore(opts), auth.AssignStatsdClient(opts))
+	authenticator, err := auth.NewAuthenticator(opts,
+		emailValidator,
+		auth.AssignProvider(opts),
+		auth.SetCSRFStore(opts),
+		auth.SetAuthCodeCipher(opts),
+		auth.AssignStatsdClient(opts),
+	)
 	if err != nil {
 		logger.Error(err, "error creating new Authenticator")
 		os.Exit(1)

--- a/internal/auth/authenticator_test.go
+++ b/internal/auth/authenticator_test.go
@@ -59,9 +59,27 @@ func setMockAuthCodeCipher(cipher *aead.MockCipher, s interface{}) func(*Authent
 	}
 }
 
-func setTestProvider(provider *providers.TestProvider) func(*Authenticator) error {
+func setTestProvider(p providers.Provider) func(*Authenticator) error {
 	return func(a *Authenticator) error {
-		a.provider = provider
+		if a.identityProviders == nil {
+			a.identityProviders = make(map[string]*IdentityProvider)
+		}
+
+		data := p.Data()
+
+		slug := data.ProviderSlug
+
+		a.identityProviders[slug] = &IdentityProvider{
+			provider: p,
+		}
+
+		return nil
+	}
+}
+
+func setMockValidator(f func(string) bool) func(*Authenticator) error {
+	return func(a *Authenticator) error {
+		a.Validator = f
 		return nil
 	}
 }
@@ -425,20 +443,23 @@ func TestSignIn(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			opts := testOpts("test", "secret")
-			opts.Validate()
-			auth, err := NewAuthenticator(opts, func(p *Authenticator) error {
-				p.Validator = func(string) bool { return tc.validEmail }
-				return nil
-			}, setMockSessionStore(tc.mockSessionStore), setMockTempl(), setMockAuthCodeCipher(tc.mockAuthCodeCipher, nil))
-			testutil.Ok(t, err)
 
+			opts.Validate()
 			// set test provider
 			u, _ := url.Parse("http://example.com")
 			provider := providers.NewTestProvider(u)
 			provider.Refresh = tc.refreshResponse.OK
 			provider.RefreshError = tc.refreshResponse.Error
 			provider.ValidToken = tc.providerValidToken
-			auth.provider = provider
+
+			auth, err := NewAuthenticator(opts,
+				setMockValidator(func(string) bool { return tc.validEmail }),
+				setMockSessionStore(tc.mockSessionStore),
+				setMockTempl(),
+				setMockAuthCodeCipher(tc.mockAuthCodeCipher, nil),
+				setTestProvider(provider),
+			)
+			testutil.Ok(t, err)
 
 			params, _ := url.ParseQuery(u.RawQuery)
 			for paramKey, val := range tc.paramsMap {
@@ -569,11 +590,12 @@ func TestSignOutPage(t *testing.T) {
 			provider := providers.NewTestProvider(u)
 			provider.RevokeError = tc.RevokeError
 
-			p, _ := NewAuthenticator(opts, func(p *Authenticator) error {
-				p.Validator = func(string) bool { return true }
-				return nil
-			}, setMockSessionStore(tc.mockSessionStore),
-				setMockTempl(), setTestProvider(provider))
+			p, _ := NewAuthenticator(opts,
+				setMockValidator(func(string) bool { return true }),
+				setMockSessionStore(tc.mockSessionStore),
+				setMockTempl(),
+				setTestProvider(provider),
+			)
 
 			params, _ := url.ParseQuery(u.RawQuery)
 
@@ -609,7 +631,7 @@ func TestValidateEndpoint(t *testing.T) {
 		Name               string
 		Endpoint           string
 		ExpectedStatusCode int
-		ProviderStatusCode int
+		ValidToken         bool
 		AccessToken        string
 		Method             string
 	}{
@@ -617,7 +639,7 @@ func TestValidateEndpoint(t *testing.T) {
 			Name:               "successful validate request",
 			Endpoint:           "/validate",
 			ExpectedStatusCode: http.StatusOK,
-			ProviderStatusCode: http.StatusOK,
+			ValidToken:         true,
 			AccessToken:        "xyz123",
 			Method:             "GET",
 		},
@@ -625,7 +647,6 @@ func TestValidateEndpoint(t *testing.T) {
 			Name:               "failed provider validate request",
 			Endpoint:           "/validate",
 			ExpectedStatusCode: http.StatusUnauthorized,
-			ProviderStatusCode: http.StatusForbidden,
 			AccessToken:        "xyz123",
 			Method:             "GET",
 		},
@@ -645,19 +666,18 @@ func TestValidateEndpoint(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			s := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-				rw.WriteHeader(tc.ProviderStatusCode)
-			}))
-			defer s.Close()
-			validateURL, _ := url.Parse(s.URL)
-
 			opts := testOpts(proxyClientID, proxyClientSecret)
 			opts.Validate()
 
-			proxy, _ := NewAuthenticator(opts)
-			proxy.provider = &providers.ProviderData{
-				ValidateURL: validateURL,
+			validateURL, err := url.Parse("https://example.com")
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
 			}
+
+			testProvider := providers.NewTestProvider(validateURL)
+			testProvider.ValidToken = tc.ValidToken
+
+			proxy, _ := NewAuthenticator(opts, setTestProvider(testProvider))
 
 			u, _ := url.Parse(tc.Endpoint)
 			params, _ := url.ParseQuery(u.RawQuery)
@@ -672,9 +692,9 @@ func TestValidateEndpoint(t *testing.T) {
 			proxy.ServeMux.ServeHTTP(rw, req)
 
 			if rw.Code != tc.ExpectedStatusCode {
-				t.Errorf("expected status code %v but response status code is %v", tc.ExpectedStatusCode, rw.Code)
+				t.Errorf("expected status code: %v", tc.ExpectedStatusCode)
+				t.Errorf("     got status code: %v", rw.Code)
 			}
-
 		})
 	}
 }
@@ -858,8 +878,11 @@ func TestRefreshEndpoint(t *testing.T) {
 			opts := testOpts("client_id", "client_secret")
 			opts.Validate()
 
-			p, _ := NewAuthenticator(opts)
-			p.provider = &testRefreshProvider{refreshFunc: tc.refreshFunc}
+			u, _ := url.Parse("http://example.com")
+			testProvider := providers.NewTestProvider(u)
+			testProvider.RefreshFunc = tc.refreshFunc
+			p, _ := NewAuthenticator(opts, setTestProvider(testProvider))
+
 			params := url.Values{}
 			params.Set("refresh_token", tc.refreshToken)
 			req := httptest.NewRequest("POST", "/", bytes.NewBufferString(params.Encode()))
@@ -928,15 +951,16 @@ func TestGetProfile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			opts := testOpts("client_id", "client_secret")
 			opts.Validate()
-			p, _ := NewAuthenticator(opts, func(p *Authenticator) error {
-				p.Validator = func(string) bool { return true }
-				return nil
-			})
+
 			u, _ := url.Parse("http://example.com")
 			testProvider := providers.NewTestProvider(u)
 			testProvider.Groups = tc.groupEmails
 			testProvider.GroupsError = tc.providerGroupError
-			p.provider = testProvider
+
+			p, _ := NewAuthenticator(opts,
+				setMockValidator(func(string) bool { return true }),
+				setTestProvider(testProvider),
+			)
 
 			req := httptest.NewRequest("GET", fmt.Sprintf("/?email=%s", tc.email), nil)
 			req.Header.Set("Accept", "application/json")
@@ -1032,21 +1056,29 @@ func TestRedeemCode(t *testing.T) {
 			opts := testOpts("client_id", "client_secret")
 			opts.Validate()
 
-			proxy, _ := NewAuthenticator(opts, func(p *Authenticator) error {
-				p.Validator = func(string) bool { return true }
-				return nil
-			})
-
 			testURL, err := url.Parse("example.com")
 			if err != nil {
 				t.Fatalf("error parsing url %s", err.Error())
 			}
-			proxy.redirectURL = testURL
 			testProvider := providers.NewTestProvider(testURL)
 			testProvider.RedeemError = tc.providerRedeemError
 			testProvider.Session = tc.expectedSessionState
-			proxy.provider = testProvider
-			sessionState, err := proxy.redeemCode(testURL.Host, tc.code)
+
+			proxy, _ := NewAuthenticator(opts,
+				setMockValidator(func(string) bool { return true }),
+				setTestProvider(testProvider),
+			)
+
+			v := url.Values{}
+			v.Set("provider_slug", "")
+			v.Set("code", tc.code)
+			proxy.redirectURL = testURL
+			req := &http.Request{
+				Host: testURL.Host,
+				Form: v,
+			}
+
+			sessionState, err := proxy.redeemCode(req)
 			if tc.expectedError && err == nil {
 				t.Errorf("expected error with message %s but no error was returned", tc.expectedErrorString)
 			}
@@ -1421,20 +1453,24 @@ func TestOAuthCallback(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			opts := testOpts("client_id", "client_secret")
 			opts.Validate()
-			proxy, _ := NewAuthenticator(opts, func(p *Authenticator) error {
-				p.Validator = func(string) bool { return tc.validEmail }
-				return nil
-			}, setMockCSRFStore(tc.csrfResp), setMockSessionStore(tc.sessionStore))
 
 			testURL, err := url.Parse("http://example.com")
 			if err != nil {
 				t.Fatalf("error parsing test url: %s", err.Error())
 			}
-			proxy.redirectURL = testURL
+
 			testProvider := providers.NewTestProvider(testURL)
 			testProvider.Session = tc.testRedeemResponse.SessionState
 			testProvider.RedeemError = tc.testRedeemResponse.Error
-			proxy.provider = testProvider
+
+			proxy, _ := NewAuthenticator(opts,
+				setMockValidator(func(string) bool { return tc.validEmail }),
+				setTestProvider(testProvider),
+				setMockCSRFStore(tc.csrfResp),
+				setMockSessionStore(tc.sessionStore),
+			)
+
+			proxy.redirectURL = testURL
 
 			params := &url.Values{}
 			for param, val := range tc.paramsMap {
@@ -1636,37 +1672,6 @@ func TestHostHeader(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestGoogleProviderApiSettings(t *testing.T) {
-	opts := testOpts("abced", "testtest")
-	opts.Provider = "google"
-	opts.Validate()
-	proxy, _ := NewAuthenticator(opts, AssignProvider(opts), func(p *Authenticator) error {
-		p.Validator = func(string) bool { return true }
-		return nil
-	})
-	p := proxy.provider.Data()
-	testutil.Equal(t, "https://accounts.google.com/o/oauth2/auth?access_type=offline",
-		p.SignInURL.String())
-	testutil.Equal(t, "https://www.googleapis.com/oauth2/v3/token",
-		p.RedeemURL.String())
-	testutil.Equal(t, "", p.ProfileURL.String())
-	testutil.Equal(t, "profile email", p.Scope)
-}
-
-func TestGoogleGroupInvalidFile(t *testing.T) {
-	opts := testOpts("abced", "testtest")
-	opts.Provider = "google"
-	opts.GoogleAdminEmail = "admin@example.com"
-	opts.GoogleServiceAccountJSON = "file_doesnt_exist.json"
-	opts.Validate()
-	_, err := NewAuthenticator(opts, AssignProvider(opts), func(p *Authenticator) error {
-		p.Validator = func(string) bool { return true }
-		return nil
-	})
-	testutil.NotEqual(t, nil, err)
-	testutil.Equal(t, "invalid Google credentials file: file_doesnt_exist.json", err.Error())
 }
 
 func TestUnimplementedProvider(t *testing.T) {

--- a/internal/auth/error.go
+++ b/internal/auth/error.go
@@ -12,6 +12,8 @@ import (
 var (
 	// ErrUserNotAuthorized is an error for unauthorized users.
 	ErrUserNotAuthorized = errors.New("user not authorized")
+	// ErrUnknownIdentityProvider denotes an unknown provider
+	ErrUnknownIdentityProvider = errors.New("unknown identity provider")
 )
 
 // HTTPError stores the status code and a message for a given HTTP error.

--- a/internal/auth/options.go
+++ b/internal/auth/options.go
@@ -319,7 +319,7 @@ func AssignProvider(opts *Options) func(*Authenticator) error {
 			return err
 		}
 		proxy.identityProviders[provider.Data().ProviderSlug] = &IdentityProvider{
-			provider,
+			provider: provider,
 		}
 		return err
 	}

--- a/internal/auth/providers/google.go
+++ b/internal/auth/providers/google.go
@@ -96,8 +96,8 @@ func NewGoogleProvider(p *ProviderData, adminEmail, credsFilePath string) (*Goog
 	return googleProvider, nil
 }
 
-// SetStatsdClient sets the google provider and admin service statsd client
-func (p *GoogleProvider) SetStatsdClient(statsdClient *statsd.Client) {
+// AssignStatsdClient sets the google provider and admin service statsd client
+func (p *GoogleProvider) AssignStatsdClient(statsdClient *statsd.Client) {
 	logger := log.NewLogEntry()
 
 	p.StatsdClient = statsdClient

--- a/internal/auth/providers/okta.go
+++ b/internal/auth/providers/okta.go
@@ -428,3 +428,7 @@ func (p *OktaProvider) Revoke(s *sessions.SessionState) error {
 	logger.WithUser(s.Email).Info("revoked access token")
 	return nil
 }
+
+func (p *OktaProvider) AssignStatsdClient(statsdClient *statsd.Client) {
+	p.StatsdClient = statsdClient
+}

--- a/internal/auth/providers/provider_data.go
+++ b/internal/auth/providers/provider_data.go
@@ -9,6 +9,7 @@ import (
 // necessary to implement the Provider interface.
 type ProviderData struct {
 	ProviderName       string
+	ProviderSlug       string
 	ClientID           string
 	ClientSecret       string
 	SignInURL          *url.URL

--- a/internal/auth/providers/provider_default.go
+++ b/internal/auth/providers/provider_default.go
@@ -12,6 +12,7 @@ import (
 
 	log "github.com/buzzfeed/sso/internal/pkg/logging"
 	"github.com/buzzfeed/sso/internal/pkg/sessions"
+	"github.com/datadog/datadog-go/statsd"
 )
 
 // Redeem takes in a redirect url and code and calls the redeem url endpoint, returning a session state if a valid
@@ -184,5 +185,10 @@ func (p *ProviderData) ValidateGroupMembership(string, []string, string) ([]stri
 
 // Stop fulfills the Provider interface
 func (p *ProviderData) Stop() {
+	return
+}
+
+// AssignStatsdClient fulfills the Provider interface
+func (p *ProviderData) AssignStatsdClient(_ *statsd.Client) {
 	return
 }

--- a/internal/auth/providers/providers.go
+++ b/internal/auth/providers/providers.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/buzzfeed/sso/internal/pkg/sessions"
+	"github.com/datadog/datadog-go/statsd"
 )
 
 var (
@@ -44,5 +45,6 @@ type Provider interface {
 	ValidateGroupMembership(string, []string, string) ([]string, error)
 	Revoke(*sessions.SessionState) error
 	RefreshAccessToken(string) (string, time.Duration, error)
+	AssignStatsdClient(*statsd.Client)
 	Stop()
 }

--- a/internal/auth/providers/singleflight_middleware.go
+++ b/internal/auth/providers/singleflight_middleware.go
@@ -62,10 +62,7 @@ func (p *SingleFlightProvider) do(endpoint, key string, fn func() (interface{}, 
 // AssignStatsdClient adds a statsd client to the provider if possible.
 func (p *SingleFlightProvider) AssignStatsdClient(StatsdClient *statsd.Client) {
 	p.StatsdClient = StatsdClient
-	switch v := p.provider.(type) {
-	case *GoogleProvider:
-		v.SetStatsdClient(StatsdClient)
-	}
+	p.provider.AssignStatsdClient(StatsdClient)
 }
 
 // Data returns the provider data

--- a/internal/auth/providers/test_provider.go
+++ b/internal/auth/providers/test_provider.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/buzzfeed/sso/internal/pkg/sessions"
+	"github.com/datadog/datadog-go/statsd"
 )
 
 // TestProvider is a test implementation of the Provider interface.
@@ -29,6 +30,7 @@ type TestProvider struct {
 func NewTestProvider(providerURL *url.URL) *TestProvider {
 	return &TestProvider{
 		ProviderData: &ProviderData{
+			ProviderSlug: "",
 			ProviderName: "Test Provider",
 			SignInURL: &url.URL{
 				Scheme: "http",
@@ -44,6 +46,11 @@ func NewTestProvider(providerURL *url.URL) *TestProvider {
 				Scheme: "http",
 				Host:   providerURL.Host,
 				Path:   "/profile",
+			},
+			ValidateURL: &url.URL{
+				Scheme: "http",
+				Host:   providerURL.Host,
+				Path:   "/validate",
 			},
 			Scope: "profile.email",
 		},
@@ -89,4 +96,12 @@ func (tp *TestProvider) Redeem(redirectURI, code string) (*sessions.SessionState
 // Stop fulfills the Provider interface
 func (tp *TestProvider) Stop() {
 	return
+}
+
+func (tp *TestProvider) AssignStatsdClient(_ *statsd.Client) {
+	return
+}
+
+func (tp *TestProvider) Data() *ProviderData {
+	return tp.ProviderData
 }

--- a/internal/pkg/logging/logging.go
+++ b/internal/pkg/logging/logging.go
@@ -279,3 +279,8 @@ func (l *LogEntry) WithUserGroup(group string) *LogEntry {
 func (l *LogEntry) WithAction(action string) *LogEntry {
 	return l.withField("action", action)
 }
+
+// WithProviderSlug appends a `provider_slug` tag to a LogEntry indicating with provider is used.
+func (l *LogEntry) WithProviderSlug(slug string) *LogEntry {
+	return l.withField("provider_slug", slug)
+}

--- a/internal/pkg/sessions/session_state.go
+++ b/internal/pkg/sessions/session_state.go
@@ -17,6 +17,8 @@ var (
 
 // SessionState is our object that keeps track of a user's session state
 type SessionState struct {
+	ProviderSlug string `json:"provider_slug"`
+
 	AccessToken  string `json:"access_token"`
 	RefreshToken string `json:"refresh_token"`
 


### PR DESCRIPTION
## Problem

As a complement to https://github.com/buzzfeed/sso/pull/180, which introduces the ability for sso proxy to specify providers per upstream, this allows sso auth to front multiple providers by accepting `provider_slug` on query parameter either as a get parameter or a body parameter for post requests. 

## Notes

Despite having underlying support to supply multiple providers, we don't yet expose the ability to configure multiple providers. We will likely leverage https://github.com/spf13/viper to extend our ability to manage complex configuration.