### PR TITLE
docker: don't run as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,8 @@ RUN cd cmd/sso-proxy && go build -o /bin/sso-proxy
 # add static assets and copy binaries from build stage
 # =============================================================================
 FROM debian:stable-slim
-RUN apt-get update && apt-get install -y ca-certificates curl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y ca-certificates curl && rm -rf /var/lib/apt/lists/* \
+    && groupadd -r sso && useradd -r -g sso sso
 WORKDIR /sso
 COPY --from=build /bin/sso-* /bin/
+USER sso


### PR DESCRIPTION
## Problem

It is best practice to run containers as a non-root user. Currently, the `sso` container runs as root.

## Solution

Create a non-root user, `sso`, in the image and configure the container to run as this user using the `USER` directive.
