### PR TITLE
sso_auth: add identity provider slug to url path and mux

### DIFF
--- a/internal/auth/metrics.go
+++ b/internal/auth/metrics.go
@@ -11,7 +11,7 @@ import (
 	"github.com/datadog/datadog-go/statsd"
 )
 
-func newStatsdClient(host string, port int) (*statsd.Client, error) {
+func NewStatsdClient(host string, port int) (*statsd.Client, error) {
 	client, err := statsd.New(net.JoinHostPort(host, strconv.Itoa(port)))
 	if err != nil {
 		return nil, err
@@ -27,16 +27,16 @@ func newStatsdClient(host string, port int) (*statsd.Client, error) {
 func GetActionTag(req *http.Request) string {
 	// only log metrics for these paths and actions
 	pathToAction := map[string]string{
-		"/robots.txt":      "robots",
-		"/start":           "start",
-		"/sign_in":         "sign_in",
-		"/sign_out":        "sign_out",
-		"/oauth2/callback": "callback",
-		"/profile":         "profile",
-		"/validate":        "validate",
-		"/redeem":          "redeem",
-		"/refresh":         "refresh",
-		"/ping":            "ping",
+		"/robots.txt": "robots",
+		"/start":      "start",
+		"/sign_in":    "sign_in",
+		"/sign_out":   "sign_out",
+		"/callback":   "callback",
+		"/profile":    "profile",
+		"/validate":   "validate",
+		"/redeem":     "redeem",
+		"/refresh":    "refresh",
+		"/ping":       "ping",
 	}
 	// get the action from the url path
 	path := req.URL.Path

--- a/internal/auth/metrics_test.go
+++ b/internal/auth/metrics_test.go
@@ -14,7 +14,7 @@ import (
 
 func newTestStatsdClient(t *testing.T) (*statsd.Client, string, int) {
 
-	client, err := newStatsdClient("127.0.0.1", 8125)
+	client, err := NewStatsdClient("127.0.0.1", 8125)
 	if err != nil {
 		t.Fatalf("error starting new statsd client %s", err.Error())
 	}
@@ -69,7 +69,7 @@ func TestNewStatsd(t *testing.T) {
 				t.Fatalf("error while instantiating config options: %s", err.Error())
 			}
 			opts.Validate()
-			client, err := newStatsdClient(tc.host, tc.port)
+			client, err := NewStatsdClient(tc.host, tc.port)
 			if err != nil {
 				t.Fatalf("error starting new statsd client: %s", err.Error())
 			}
@@ -226,12 +226,12 @@ func TestGetActionTag(t *testing.T) {
 		},
 		{
 			name:           "request with callback in the path",
-			url:            "/oauth2/callback",
+			url:            "/callback",
 			expectedAction: "callback",
 		},
 		{
 			name:           "request with sign_out in the path with query parameters",
-			url:            "/oauth2/callback?query=parameter",
+			url:            "/callback?query=parameter",
 			expectedAction: "callback",
 		},
 		{

--- a/internal/auth/mux.go
+++ b/internal/auth/mux.go
@@ -60,11 +60,6 @@ func NewAuthenticatorMux(opts *Options, statsdClient *statsd.Client) (*Authentic
 			fmt.Sprintf("/%s/", idpSlug),
 			http.StripPrefix(fmt.Sprintf("/%s", idpSlug), authenticator.ServeMux),
 		)
-
-		// we setup default routes for the default provider, mainly helpful for transitionary services
-		if idpSlug == opts.DefaultProvider {
-			idpMux.Handle("/", authenticator.ServeMux)
-		}
 	}
 
 	// load static files

--- a/internal/auth/mux.go
+++ b/internal/auth/mux.go
@@ -1,0 +1,109 @@
+package auth
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/buzzfeed/sso/internal/auth/providers"
+	log "github.com/buzzfeed/sso/internal/pkg/logging"
+	"github.com/buzzfeed/sso/internal/pkg/options"
+
+	"github.com/datadog/datadog-go/statsd"
+)
+
+type AuthenticatorMux struct {
+	mux            *http.ServeMux
+	authenticators []*Authenticator
+}
+
+func NewAuthenticatorMux(opts *Options, statsdClient *statsd.Client) (*AuthenticatorMux, error) {
+	logger := log.NewLogEntry()
+
+	emailValidator := func(p *Authenticator) error {
+		if len(opts.EmailAddresses) != 0 {
+			p.Validator = options.NewEmailAddressValidator(opts.EmailAddresses)
+		} else {
+			p.Validator = options.NewEmailDomainValidator(opts.EmailDomains)
+		}
+		return nil
+	}
+
+	// one day, we will contruct more providers here
+	idp, err := newProvider(opts)
+	if err != nil {
+		logger.Error(err, "error creating new Identity Provider")
+		return nil, err
+	}
+	identityProviders := []providers.Provider{idp}
+	authenticators := []*Authenticator{}
+
+	idpMux := http.NewServeMux()
+	for _, idp := range identityProviders {
+		idpSlug := idp.Data().ProviderSlug
+		authenticator, err := NewAuthenticator(opts,
+			emailValidator,
+			SetProvider(idp),
+			SetCookieStore(opts, idpSlug),
+			SetStatsdClient(statsdClient),
+			SetRedirectURL(opts, idpSlug),
+		)
+		if err != nil {
+			logger.Error(err, "error creating new Authenticator")
+			return nil, err
+		}
+
+		authenticators = append(authenticators, authenticator)
+
+		// setup our mux with the idpslug as the first part of the path
+		idpMux.Handle(
+			fmt.Sprintf("/%s/", idpSlug),
+			http.StripPrefix(fmt.Sprintf("/%s", idpSlug), authenticator.ServeMux),
+		)
+
+		// we setup default routes for the default provider, mainly helpful for transitionary services
+		if idpSlug == opts.DefaultProvider {
+			idpMux.Handle("/", authenticator.ServeMux)
+		}
+	}
+
+	// load static files
+	fsHandler, err := loadFSHandler()
+	if err != nil {
+		logger.Fatal(err)
+	}
+	idpMux.Handle("/static/", http.StripPrefix("/static/", fsHandler))
+
+	// NOTE: we have to include trailing slash for the router to match the host header
+	host := opts.Host
+	if !strings.HasSuffix(host, "/") {
+		host = fmt.Sprintf("%s/", host)
+	}
+
+	mux := http.NewServeMux()
+	// We setup our IPD Mux only on our declared host header
+	mux.Handle(host, idpMux) // setup our service mux to only handle our required host header
+	// Ping should respond to all requests
+	mux.HandleFunc("/ping", PingHandler)
+
+	return &AuthenticatorMux{
+		mux:            mux,
+		authenticators: authenticators,
+	}, nil
+}
+
+func (a *AuthenticatorMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	a.mux.ServeHTTP(w, r)
+}
+
+func (a *AuthenticatorMux) Stop() {
+	for _, authenticator := range a.authenticators {
+		authenticator.Stop()
+	}
+}
+
+// PingHandler handles the /ping route
+func PingHandler(rw http.ResponseWriter, req *http.Request) {
+	rw.WriteHeader(http.StatusOK)
+	fmt.Fprintf(rw, http.StatusText(http.StatusOK))
+}

--- a/internal/auth/mux_test.go
+++ b/internal/auth/mux_test.go
@@ -1,0 +1,76 @@
+package auth
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestHostHeader(t *testing.T) {
+	testCases := []struct {
+		Name               string
+		Host               string
+		RequestHost        string
+		Path               string
+		ExpectedStatusCode int
+	}{
+		{
+			Name:               "reject requests with an invalid hostname",
+			Host:               "example.com",
+			RequestHost:        "unknown.com",
+			Path:               "/static/sso.css",
+			ExpectedStatusCode: http.StatusNotFound,
+		},
+		{
+			Name:               "allow requests to any hostname to /ping",
+			Host:               "example.com",
+			RequestHost:        "unknown.com",
+			Path:               "/ping",
+			ExpectedStatusCode: http.StatusOK,
+		},
+		{
+			Name:               "allow requests with a valid hostname",
+			Host:               "example.com",
+			RequestHost:        "example.com",
+			Path:               "/static/sso.css",
+			ExpectedStatusCode: http.StatusOK,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			opts := testOpts(t, "abced", "testtest")
+			opts.Host = tc.Host
+			err := opts.Validate()
+			if err != nil {
+				t.Fatalf("unexpected opts error: %v", err)
+			}
+
+			opts.redirectURL = &url.URL{
+				Host:   tc.Host,
+				Path:   "/callback",
+				Scheme: "https",
+			}
+
+			authMux, err := NewAuthenticatorMux(opts, nil)
+			if err != nil {
+				t.Fatalf("unexpected err creating auth mux: %v", err)
+			}
+
+			uri := fmt.Sprintf("http://%s%s", tc.RequestHost, tc.Path)
+
+			rw := httptest.NewRecorder()
+			req := httptest.NewRequest("GET", uri, nil)
+
+			authMux.ServeHTTP(rw, req)
+			if rw.Code != tc.ExpectedStatusCode {
+				t.Errorf("got unexpected status code")
+				t.Errorf("want %v", tc.ExpectedStatusCode)
+				t.Errorf(" got %v", rw.Code)
+				t.Errorf(" headers %v", rw)
+				t.Errorf(" body: %q", rw.Body)
+			}
+		})
+	}
+}

--- a/internal/auth/options.go
+++ b/internal/auth/options.go
@@ -40,7 +40,6 @@ import (
 // CookieRefresh - duration - refresh the cookie after this duration default 0
 // CookieSecure - bool - set secure (HTTPS) cookie flag
 // CookieHTTPOnly - bool - set httponly cookie flag
-// DefaultProvider - string - specify the default provider
 // RequestTimeout - duration - overall request timeout
 // AuthCodeSecret - string - the seed string for secure auth codes (optionally base64 encoded)
 // GroupCacheProviderTTL - time.Duration - cache TTL for the group-cache provider used for on-demand group caching
@@ -50,6 +49,7 @@ import (
 // PassUserHeaders - bool (default true) - pass X-Forwarded-User and X-Forwarded-Email information to upstream
 // SetXAuthRequest - set X-Auth-Request-User and X-Auth-Request-Email response headers (useful in Nginx auth_request mode)
 // Provider - provider name
+// ProviderSlug - string - client-side string used to uniquely identify a specific instantiation of an identity provider
 // ProviderServerID - string - if using Okta as the provider, the authorisation server ID (defaults to 'default')
 // SignInURL - provider sign in endpoint
 // RedeemURL - provider token redemption endpoint
@@ -109,8 +109,6 @@ type Options struct {
 	Provider         string `mapstructure:"provider"`
 	ProviderSlug     string `mapstructure:"provider_slug"`
 	ProviderServerID string `mapstructure:"provider_server_id"`
-
-	DefaultProvider string `mapstructure:"default_provider"`
 
 	SignInURL      string `mapstructure:"signin_url"`
 	RedeemURL      string `mapstructure:"redeem_url"`

--- a/internal/auth/options_test.go
+++ b/internal/auth/options_test.go
@@ -68,10 +68,10 @@ func TestInitializedOptions(t *testing.T) {
 // seems to parse damn near anything.
 func TestRedirectURL(t *testing.T) {
 	o := testOptions(t)
-	o.RedirectURL = "https://myhost.com/oauth2/callback"
+	o.RedirectURL = "https://myhost.com/callback"
 	testutil.Equal(t, nil, o.Validate())
 	expected := &url.URL{
-		Scheme: "https", Host: "myhost.com", Path: "/oauth2/callback"}
+		Scheme: "https", Host: "myhost.com", Path: "/callback"}
 	testutil.Equal(t, expected, o.redirectURL)
 }
 

--- a/internal/auth/providers/provider_data.go
+++ b/internal/auth/providers/provider_data.go
@@ -9,6 +9,7 @@ import (
 // necessary to implement the Provider interface.
 type ProviderData struct {
 	ProviderName       string
+	ProviderSlug       string
 	ClientID           string
 	ClientSecret       string
 	SignInURL          *url.URL

--- a/internal/pkg/templates/templates.go
+++ b/internal/pkg/templates/templates.go
@@ -64,7 +64,7 @@ Secured by <b>SSO</b>{{end}}`))
 
             {{template "sign_in_message.html" .}}
 
-            <form method="GET" action="/start">
+            <form method="GET" action="start">
                 <input type="hidden" name="redirect_uri" value="{{.Redirect}}">
                 <button type="submit" class="btn">Sign in with {{.ProviderName}}</button>
             </form>
@@ -117,7 +117,7 @@ Secured by <b>SSO</b>{{end}}`))
             </header>
 
             <p>You're currently signed in as <b>{{.Email}}</b>. This will also sign you out of other internal apps.</p>
-            <form method="POST" action="/sign_out">
+            <form method="POST" action="sign_out">
               <input type="hidden" name="redirect_uri" value="{{.Redirect}}">
               <input type="hidden" name="sig" value="{{.Signature}}">
               <input type="hidden" name="ts" value="{{.Timestamp}}">

--- a/internal/proxy/options.go
+++ b/internal/proxy/options.go
@@ -41,6 +41,7 @@ import (
 // CookieHTTPOnly - set HttpOnly cookie flag
 // PassAccessToken - send access token in the http headers
 // Provider - OAuth provider
+// ProviderSlug - OAuth provider slug, used internally to identity a specific provider
 // Scope - OAuth scope specification
 // SessionLifetimeTTL - time to live for a session lifetime
 // SessionValidTTL - time to live for a valid session
@@ -81,9 +82,9 @@ type Options struct {
 
 	PassAccessToken bool `envconfig:"PASS_ACCESS_TOKEN" default:"false"`
 
-	// These options allow for other providers besides Google, with potential overrides.
-	Provider string `envconfig:"PROVIDER" default:"google"`
-	Scope    string `envconfig:"SCOPE"`
+	Provider     string `envconfig:"PROVIDER" default:"sso"`
+	ProviderSlug string `envconfig:"PROVIDER_SLUG" default:"google"`
+	Scope        string `envconfig:"SCOPE"`
 
 	SessionLifetimeTTL time.Duration `envconfig:"SESSION_LIFETIME_TTL" default:"720h"`
 	SessionValidTTL    time.Duration `envconfig:"SESSION_VALID_TTL" default:"1m"`
@@ -257,6 +258,7 @@ func parseProviderInfo(o *Options) error {
 		ClientSecret:        o.ClientSecret,
 		ProviderURL:         providerURL,
 		ProviderURLInternal: providerURLInternal,
+		ProviderSlug:        o.ProviderSlug,
 		Scope:               o.Scope,
 		SessionLifetimeTTL:  o.SessionLifetimeTTL,
 		SessionValidTTL:     o.SessionValidTTL,

--- a/internal/proxy/options_test.go
+++ b/internal/proxy/options_test.go
@@ -17,6 +17,7 @@ func testOptions() *Options {
 	o.ClientID = "bazquux"
 	o.ClientSecret = "xyzzyplugh"
 	o.EmailDomains = []string{"*"}
+	o.ProviderSlug = "idp"
 	o.ProviderURLString = "https://www.example.com"
 	o.UpstreamConfigsFile = "testdata/upstream_configs.yml"
 	o.Cluster = "sso"
@@ -67,15 +68,15 @@ func TestDefaultProviderApiSettings(t *testing.T) {
 	o := testOptions()
 	testutil.Equal(t, nil, o.Validate())
 	p := o.provider.Data()
-	testutil.Equal(t, "https://www.example.com/sign_in",
+	testutil.Equal(t, "https://www.example.com/idp/sign_in",
 		p.SignInURL.String())
-	testutil.Equal(t, "https://www.example.com/sign_out",
+	testutil.Equal(t, "https://www.example.com/idp/sign_out",
 		p.SignOutURL.String())
-	testutil.Equal(t, "https://www.example.com/redeem",
+	testutil.Equal(t, "https://www.example.com/idp/redeem",
 		p.RedeemURL.String())
-	testutil.Equal(t, "https://www.example.com/validate",
+	testutil.Equal(t, "https://www.example.com/idp/validate",
 		p.ValidateURL.String())
-	testutil.Equal(t, "https://www.example.com/profile",
+	testutil.Equal(t, "https://www.example.com/idp/profile",
 		p.ProfileURL.String())
 	testutil.Equal(t, "", p.Scope)
 }
@@ -92,12 +93,12 @@ func TestProviderURLValidation(t *testing.T) {
 		{
 			name:              "http scheme preserved",
 			providerURLString: "http://provider.example.com",
-			expectedSignInURL: "http://provider.example.com/sign_in",
+			expectedSignInURL: "http://provider.example.com/idp/sign_in",
 		},
 		{
 			name:              "https scheme preserved",
 			providerURLString: "https://provider.example.com",
-			expectedSignInURL: "https://provider.example.com/sign_in",
+			expectedSignInURL: "https://provider.example.com/idp/sign_in",
 		},
 		{
 			name:                              "proxy provider url string based on providerURL",

--- a/internal/proxy/providers/provider_data.go
+++ b/internal/proxy/providers/provider_data.go
@@ -9,6 +9,7 @@ import (
 // necessary to implement the Provider interface.
 type ProviderData struct {
 	ProviderName        string
+	ProviderSlug        string
 	ProviderURL         *url.URL
 	ProviderURLInternal *url.URL
 	ClientID            string

--- a/internal/proxy/providers/sso.go
+++ b/internal/proxy/providers/sso.go
@@ -57,6 +57,8 @@ func init() {
 // a statsd client.
 func NewSSOProvider(p *ProviderData, sc *statsd.Client) *SSOProvider {
 	p.ProviderName = "SSO"
+	slug := p.ProviderSlug
+
 	base := p.ProviderURL
 	internalBase := base
 
@@ -64,13 +66,15 @@ func NewSSOProvider(p *ProviderData, sc *statsd.Client) *SSOProvider {
 		internalBase = p.ProviderURLInternal
 	}
 
-	p.SignInURL = base.ResolveReference(&url.URL{Path: "/sign_in"})
-	p.SignOutURL = base.ResolveReference(&url.URL{Path: "/sign_out"})
+	// These endpoints are for end clients and have end-client resolvable addresses.
+	p.SignInURL = base.ResolveReference(&url.URL{Path: fmt.Sprintf("/%s/sign_in", slug)})
+	p.SignOutURL = base.ResolveReference(&url.URL{Path: fmt.Sprintf("/%s/sign_out", slug)})
 
-	p.RedeemURL = internalBase.ResolveReference(&url.URL{Path: "/redeem"})
-	p.RefreshURL = internalBase.ResolveReference(&url.URL{Path: "/refresh"})
-	p.ValidateURL = internalBase.ResolveReference(&url.URL{Path: "/validate"})
-	p.ProfileURL = internalBase.ResolveReference(&url.URL{Path: "/profile"})
+	// These are endpoints that used for internally and may have internal-only resolvable addresses.
+	p.RedeemURL = internalBase.ResolveReference(&url.URL{Path: fmt.Sprintf("/%s/redeem", slug)})
+	p.RefreshURL = internalBase.ResolveReference(&url.URL{Path: fmt.Sprintf("/%s/refresh", slug)})
+	p.ValidateURL = internalBase.ResolveReference(&url.URL{Path: fmt.Sprintf("/%s/validate", slug)})
+	p.ProfileURL = internalBase.ResolveReference(&url.URL{Path: fmt.Sprintf("/%s/profile", slug)})
 
 	return &SSOProvider{
 		ProviderData: p,

--- a/internal/proxy/providers/sso_test.go
+++ b/internal/proxy/providers/sso_test.go
@@ -27,6 +27,7 @@ func newTestServer(status int, body []byte) (*url.URL, *httptest.Server) {
 func newSSOProvider() *SSOProvider {
 	return NewSSOProvider(
 		&ProviderData{
+			ProviderSlug: "idp",
 			ProviderURL: &url.URL{
 				Scheme: "https",
 				Host:   "auth.example.com",
@@ -98,16 +99,18 @@ func TestSSOProviderDefaults(t *testing.T) {
 	data := p.Data()
 	testutil.Equal(t, "SSO", data.ProviderName)
 
+	slug := data.ProviderSlug
+
 	base := fmt.Sprintf("%s://%s", data.ProviderURL.Scheme, data.ProviderURL.Host)
 	internalBase := fmt.Sprintf("%s://%s", data.ProviderURLInternal.Scheme, data.ProviderURLInternal.Host)
 
-	testutil.Equal(t, fmt.Sprintf("%s/sign_in", base), data.SignInURL.String())
-	testutil.Equal(t, fmt.Sprintf("%s/sign_out", base), data.SignOutURL.String())
+	testutil.Equal(t, fmt.Sprintf("%s/%s/sign_in", base, slug), data.SignInURL.String())
+	testutil.Equal(t, fmt.Sprintf("%s/%s/sign_out", base, slug), data.SignOutURL.String())
 
-	testutil.Equal(t, fmt.Sprintf("%s/redeem", internalBase), data.RedeemURL.String())
-	testutil.Equal(t, fmt.Sprintf("%s/refresh", internalBase), data.RefreshURL.String())
-	testutil.Equal(t, fmt.Sprintf("%s/validate", internalBase), data.ValidateURL.String())
-	testutil.Equal(t, fmt.Sprintf("%s/profile", internalBase), data.ProfileURL.String())
+	testutil.Equal(t, fmt.Sprintf("%s/%s/redeem", internalBase, slug), data.RedeemURL.String())
+	testutil.Equal(t, fmt.Sprintf("%s/%s/refresh", internalBase, slug), data.RefreshURL.String())
+	testutil.Equal(t, fmt.Sprintf("%s/%s/validate", internalBase, slug), data.ValidateURL.String())
+	testutil.Equal(t, fmt.Sprintf("%s/%s/profile", internalBase, slug), data.ProfileURL.String())
 }
 
 type redeemResponse struct {


### PR DESCRIPTION
## Problem

As we move towards supporting multiple providers within `sso-auth`, we need to provide unique callback urls for each identity provider.

## Solution

We add more provider slug prefixes to url paths and supply a default provider to support unique callback urls as well as preserve backward's compatibility

## Notes
* Creates a new `AuthenticatorMux` struct to house the mux mechanism for multiple `Authenticators`
* Move initialization from `main.go` to `NewAuthenticatorMux`
* Make `newStatsdClient` public to call from initialization from `main.go`
* Add new `Slug` struct field to `ProviderData` to differentiate between providers. 
