### PR TITLE
Configure Proxy CookieName via Env Var

### DIFF
--- a/internal/proxy/options.go
+++ b/internal/proxy/options.go
@@ -73,7 +73,7 @@ type Options struct {
 	TCPWriteTimeout time.Duration `envconfig:"TCP_WRITE_TIMEOUT" default:"30s"`
 	TCPReadTimeout  time.Duration `envconfig:"TCP_READ_TIMEOUT" default:"30s"`
 
-	CookieName     string
+	CookieName     string        `envconfig:"COOKIE_NAME" default:"_sso_proxy"`
 	CookieSecret   string        `envconfig:"COOKIE_SECRET"`
 	CookieDomain   string        `envconfig:"COOKIE_DOMAIN"`
 	CookieExpire   time.Duration `envconfig:"COOKIE_EXPIRE" default:"168h"`


### PR DESCRIPTION
## Problem

See #197 

## Solution

Add a COOKIE_NAME env var to the option struct

## Notes

It looks like there are already some tests around custom cookie name values, and I couldn't find any tests based around environment variables I couldn't find any, but if there are some tests needed do let me know!
