### PR TITLE
sso: enable golangci-lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,10 +15,6 @@ jobs:
           name: get tools
           command: make tools
       - run:
-          name: copy source
-          command: |
-            mkdir bin
-      - run:
           name: run lint and tests for both services
           command: |
             scripts/test

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 version := "v1.2.0"
 
 commit := $(shell git rev-parse --short HEAD)
+gopath := $(shell go env GOPATH)
 
 
 build: dist/sso-auth dist/sso-proxy
@@ -16,7 +17,7 @@ dist/sso-proxy:
 	go build -o dist/sso-proxy ./cmd/sso-proxy
 
 tools:
-	go get golang.org/x/lint/golint
+	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(gopath)/bin v1.16.0
 	go get github.com/rakyll/statik 
 
 test:

--- a/scripts/test
+++ b/scripts/test
@@ -3,13 +3,8 @@ set -e
 
 cd $(dirname "$BASH_SOURCE[0]")/..
 
-echo "running go fmt ..."
-res=$(go fmt ./...)
-if [ -n "$res" ]; then
-  echo "$res"
-  echo "gofmt failed..."
-  exit 1
-fi
+echo "running golangci-lint ..."
+golangci-lint run -E gofmt -E golint -E gocritic -E gosec -E misspell
 
 # where necessary attempts to add/remove modules from go.mod and go.sum.
 echo "running go mod tidy ..."
@@ -23,12 +18,6 @@ fi
 # with a non-zero status.
 echo "running go mod verify ..."
 go mod verify
-
-echo "running golint ..."
-golint -set_exit_status cmd internal
-
-echo "running go vet ..."
-go vet ./...
 
 echo "running tests ..."
 cd internal


### PR DESCRIPTION
## Problem

We have a limited number of linters and other static code analyzers. We should add more to improve our codebase and make review better and easier.

## Solution

`golangci-lint` https://github.com/golangci/golangci-lint is the newest replacement for `gometalinter` which has been the staple multi-lint tool. This PR adds support for `golangci-lint` as well as fixes the codebase so it runs cleanly.

## Notes
Default linters include:
* deadcode
* errcheck
* gosimple
* govet
* ineffassign
* staticcheck
* structcheck
* typecheck
* unused:
* varcheck

We also enable additional linters:
* gofmt
* golint
* gocritic
* gosec
* misspell

We can add other linters in the future but I'd like to focus on getting the defaults