### PR TITLE
sso_proxy: don't set timeout when flush interval is set

### DIFF
--- a/internal/proxy/reverse_proxy.go
+++ b/internal/proxy/reverse_proxy.go
@@ -109,7 +109,8 @@ func NewUpstreamReverseProxy(config *UpstreamConfig, signer *RequestSigner) (htt
 	var handler http.Handler = reverseProxy
 
 	// Apply a timeout handler if configured
-	if config.Timeout != 0 {
+	// http.TimeoutHandler doesn't support flushing, so only create one if no flush interval is set.
+	if config.FlushInterval == 0 && config.Timeout != 0 {
 		handler = newTimeoutHandler(handler, config)
 	}
 


### PR DESCRIPTION
## Problem

`http.TimeoutHandler` doesn't support request flushing, resulting in any flush interval set being ignored if a timeout is also set (we set a default timeout, but not flush interval, so right now this problem always occurs if a flush interval is set).

https://golang.org/src/net/http/server.go?s=98830:98898#L3129

## Solution

If a flush interval is set in the upstream config, return the handler without setting a timeout.

