### PR TITLE
sso_auth: add default provider slug

### DIFF
--- a/internal/auth/authenticator.go
+++ b/internal/auth/authenticator.go
@@ -139,7 +139,6 @@ func NewAuthenticator(opts *Options, optionFuncs ...func(*Authenticator) error) 
 func (p *Authenticator) newMux() http.Handler {
 	// we setup our service mux to handle service routes that use the required host header
 	serviceMux := http.NewServeMux()
-	serviceMux.HandleFunc("/robots.txt", p.withMethods(p.RobotsTxt, "GET"))
 	serviceMux.HandleFunc("/start", p.withMethods(p.OAuthStart, "GET"))
 	serviceMux.HandleFunc("/sign_in", p.withMethods(p.validateClientID(p.validateRedirectURI(p.validateSignature(p.SignIn))), "GET"))
 	serviceMux.HandleFunc("/sign_out", p.withMethods(p.validateRedirectURI(p.validateSignature(p.SignOut)), "GET", "POST"))
@@ -158,12 +157,6 @@ func (p *Authenticator) GetRedirectURI(host string) string {
 	// default to the request Host if not set
 	return p.redirectURL.String()
 
-}
-
-// RobotsTxt handles the /robots.txt route.
-func (p *Authenticator) RobotsTxt(rw http.ResponseWriter, req *http.Request) {
-	rw.WriteHeader(http.StatusOK)
-	fmt.Fprintf(rw, "User-agent: *\nDisallow: /")
 }
 
 type signInResp struct {

--- a/internal/auth/authenticator_test.go
+++ b/internal/auth/authenticator_test.go
@@ -708,25 +708,36 @@ func TestGetAuthCodeRedirectURL(t *testing.T) {
 		name        string
 		redirectURI string
 		expectedURI string
+		scheme      string
 	}{
 		{
 			name:        "url scheme included",
+			scheme:      "http",
 			redirectURI: "http://example.com",
 			expectedURI: "http://example.com?code=code&state=state",
 		},
 		{
 			name:        "url scheme not included",
+			scheme:      "https",
 			redirectURI: "example.com",
 			expectedURI: "https://example.com?code=code&state=state",
 		},
 		{
 			name:        "auth code is overwritten",
+			scheme:      "http",
 			redirectURI: "http://example.com?code=different",
 			expectedURI: "http://example.com?code=code&state=state",
 		},
 		{
 			name:        "state is overwritten",
+			scheme:      "https",
 			redirectURI: "https://example.com?state=different",
+			expectedURI: "https://example.com?code=code&state=state",
+		},
+		{
+			name:        "scheme is overwritten",
+			scheme:      "https",
+			redirectURI: "http://example.com?state=different",
 			expectedURI: "https://example.com?code=code&state=state",
 		},
 	}
@@ -738,7 +749,12 @@ func TestGetAuthCodeRedirectURL(t *testing.T) {
 			if err != nil {
 				t.Fatalf("error parsing redirect uri %s", err.Error())
 			}
-			uri := getAuthCodeRedirectURL(redirectURL, "state", "code")
+
+			uri, err := getAuthCodeRedirectURL(redirectURL, "state", "code", tc.scheme)
+			if err != nil {
+				t.Fatalf("unexpected err generating auth code redirect url: %v", err)
+			}
+
 			if uri != tc.expectedURI {
 				t.Errorf("expected redirect uri to be %s but was %s", tc.expectedURI, uri)
 			}

--- a/internal/auth/authenticator_test.go
+++ b/internal/auth/authenticator_test.go
@@ -137,24 +137,6 @@ func newRevokeServer(accessToken string) (*url.URL, *httptest.Server) {
 	return u, s
 }
 
-func TestRobotsTxt(t *testing.T) {
-	opts := testOpts(t, "abced", "testtest")
-	opts.Validate()
-	proxy, _ := NewAuthenticator(opts, func(p *Authenticator) error {
-		p.Validator = func(string) bool { return true }
-		return nil
-	})
-	rw := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/robots.txt", nil)
-	proxy.ServeMux.ServeHTTP(rw, req)
-	if rw.Code != http.StatusOK {
-		t.Errorf("expected status code %d, but got %d", http.StatusOK, rw.Code)
-	}
-	if rw.Body.String() != "User-agent: *\nDisallow: /" {
-		t.Errorf("expected response body to be %s but was %s", "User-agent: *\nDisallow: /", rw.Body.String())
-	}
-}
-
 const redirectInputPattern = `<input type="hidden" name="redirect_uri" value="([^"]+)">`
 const revokeErrorMessagePattern = `An error occurred during sign out\. Please try again\.`
 

--- a/internal/auth/mux.go
+++ b/internal/auth/mux.go
@@ -61,6 +61,8 @@ func NewAuthenticatorMux(opts *Options, statsdClient *statsd.Client) (*Authentic
 			http.StripPrefix(fmt.Sprintf("/%s", idpSlug), authenticator.ServeMux),
 		)
 
+		// TODO: This should be removed once we feel confident clients have been moved over to the new
+		// style /slug/ paths. This is kept around to allow graceful migrations/upgrades.
 		if idpSlug == opts.DefaultProviderSlug {
 			// setup our mux with the idpslug as the first part of the path
 			authenticator, err := NewAuthenticator(opts,

--- a/internal/auth/mux_test.go
+++ b/internal/auth/mux_test.go
@@ -74,3 +74,69 @@ func TestHostHeader(t *testing.T) {
 		})
 	}
 }
+
+func TestDefaultProvider(t *testing.T) {
+	testCases := []struct {
+		Name               string
+		Host               string
+		ExpectedStatusCode int
+	}{
+		{
+			Name:               "similar requests to default path should get same results as slug path",
+			Host:               "example.com",
+			ExpectedStatusCode: http.StatusBadRequest,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			opts := testOpts(t, "abced", "testtest")
+			opts.Host = tc.Host
+			err := opts.Validate()
+			if err != nil {
+				t.Fatalf("unexpected opts error: %v", err)
+			}
+
+			authMux, err := NewAuthenticatorMux(opts, nil)
+			if err != nil {
+				t.Fatalf("unexpected err creating auth mux: %v", err)
+			}
+
+			for _, path := range []string{"/callback", "/google/callback"} {
+				uri := fmt.Sprintf("http://%s%s", tc.Host, path)
+
+				rw := httptest.NewRecorder()
+				req := httptest.NewRequest("GET", uri, nil)
+
+				authMux.ServeHTTP(rw, req)
+				if rw.Code != tc.ExpectedStatusCode {
+					t.Errorf("got unexpected status code")
+					t.Errorf("want %v", tc.ExpectedStatusCode)
+					t.Errorf(" got %v", rw.Code)
+					t.Errorf(" headers %v", rw)
+					t.Errorf(" body: %q", rw.Body)
+				}
+			}
+		})
+	}
+}
+
+func TestRobotsTxt(t *testing.T) {
+	opts := testOpts(t, "abced", "testtest")
+	opts.Host = "example.com"
+	opts.Validate()
+	authMux, err := NewAuthenticatorMux(opts, nil)
+	if err != nil {
+		t.Fatalf("unexpected err creating auth mux: %v", err)
+	}
+
+	rw := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "https://example.com/robots.txt", nil)
+	authMux.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Errorf("expected status code %d, but got %d", http.StatusOK, rw.Code)
+	}
+	if rw.Body.String() != "User-agent: *\nDisallow: /" {
+		t.Errorf("expected response body to be %s but was %s", "User-agent: *\nDisallow: /", rw.Body.String())
+	}
+}

--- a/internal/auth/options.go
+++ b/internal/auth/options.go
@@ -44,6 +44,7 @@ import (
 // Provider - provider name
 // ProviderSlug - string - client-side string used to uniquely identify a specific instantiation of an identity provider
 // ProviderServerID - string - if using Okta as the provider, the authorisation server ID (defaults to 'default')
+// DefaultProviderSlug - string = default client-side string to use as the default identity provider
 // Scope - Oauth scope specification
 // ApprovalPrompt - OAuth approval prompt
 // RequestLogging - bool to log requests
@@ -89,6 +90,9 @@ type Options struct {
 	Provider         string `mapstructure:"provider"`
 	ProviderSlug     string `mapstructure:"provider_slug"`
 	ProviderServerID string `mapstructure:"provider_server_id"`
+
+	// These is the default provider
+	DefaultProviderSlug string `mapstructure:"default_provider_slug"`
 
 	Scope          string `mapstructure:"scope"`
 	ApprovalPrompt string `mapstructure:"approval_prompt"`
@@ -157,6 +161,7 @@ func setDefaults(v *viper.Viper) {
 		"provider":                 "google",
 		"provider_slug":            "google",
 		"provider_server_id":       "default",
+		"default_provider_slug":    "google",
 		"approval_prompt":          "force",
 		"request_logging":          true,
 		"request_timeout":          "2s",
@@ -332,6 +337,16 @@ func SetRedirectURL(opts *Options, slug string) func(*Authenticator) error {
 	return func(a *Authenticator) error {
 		a.redirectURL = &url.URL{
 			Path: path.Join(slug, "callback"),
+		}
+		return nil
+	}
+}
+
+// SetDefaultRedirectURL takes an options struct to construct the url callback and redirect.
+func SetDefaultRedirectURL(opts *Options) func(*Authenticator) error {
+	return func(a *Authenticator) error {
+		a.redirectURL = &url.URL{
+			Path: path.Join("callback"),
 		}
 		return nil
 	}

--- a/internal/auth/options.go
+++ b/internal/auth/options.go
@@ -358,3 +358,11 @@ func SetDefaultRedirectURL(opts *Options) func(*Authenticator) error {
 		return nil
 	}
 }
+
+// SetValidator sets the email validator
+func SetValidator(validator func(string) bool) func(*Authenticator) error {
+	return func(a *Authenticator) error {
+		a.Validator = validator
+		return nil
+	}
+}

--- a/internal/auth/options.go
+++ b/internal/auth/options.go
@@ -24,6 +24,7 @@ import (
 // OrgName - string - if using Okta as the provider, the Okta domain to use
 // ProxyClientID - string - the client id that matches the sso proxy client id
 // ProxyClientSecret - string - the client secret that matches the sso proxy client secret
+// Scheme - string - The scheme to use for internal redirects
 // Host - string - The host that is in the header that is required on incoming requests
 // Port - string - Port to listen on
 // EmailDomains - []string - authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email
@@ -56,8 +57,9 @@ type Options struct {
 	ProxyClientID     string `mapstructure:"proxy_client_id"`
 	ProxyClientSecret string `mapstructure:"proxy_client_secret"`
 
-	Host string `mapstructure:"host"`
-	Port int    `mapstructure:"port"`
+	Scheme string `mapstructure:"scheme"`
+	Host   string `mapstructure:"host"`
+	Port   int    `mapstructure:"port"`
 
 	EmailDomains     []string `mapstructure:"sso_email_domain"`
 	EmailAddresses   []string `mapstructure:"sso_email_addresses"`
@@ -148,6 +150,7 @@ func bindAllOptVars(v *viper.Viper, t reflect.Type, tag string) error {
 func setDefaults(v *viper.Viper) {
 	defaultVars := map[string]interface{}{
 		"port":                     4180,
+		"scheme":                   "https",
 		"cookie_expire":            "168h",
 		"cookie_name":              "_sso_auth",
 		"cookie_refresh":           "1h",
@@ -336,7 +339,9 @@ func SetStatsdClient(statsdClient *statsd.Client) func(*Authenticator) error {
 func SetRedirectURL(opts *Options, slug string) func(*Authenticator) error {
 	return func(a *Authenticator) error {
 		a.redirectURL = &url.URL{
-			Path: path.Join(slug, "callback"),
+			Scheme: opts.Scheme,
+			Host:   opts.Host,
+			Path:   path.Join(slug, "callback"),
 		}
 		return nil
 	}
@@ -346,7 +351,9 @@ func SetRedirectURL(opts *Options, slug string) func(*Authenticator) error {
 func SetDefaultRedirectURL(opts *Options) func(*Authenticator) error {
 	return func(a *Authenticator) error {
 		a.redirectURL = &url.URL{
-			Path: path.Join("callback"),
+			Scheme: opts.Scheme,
+			Host:   opts.Host,
+			Path:   path.Join("callback"),
 		}
 		return nil
 	}


### PR DESCRIPTION
## Problem

After some reflection, we should add configuration for a default identity provider with `sso_auth` to make migrations easier and more seamless.

## Solution

Add additional configuration for the default provider slug and set up a default identity provider at the path root.

This also fixes `/robots.txt` which is mistakenly left dangling on the idp slug path.