### PR TITLE
sso: rename request timing metric

### DIFF
--- a/internal/auth/metrics.go
+++ b/internal/auth/metrics.go
@@ -69,6 +69,6 @@ func logRequestMetrics(proxyHost string, req *http.Request, requestDuration time
 	}
 
 	// TODO: eventually make rates configurable
-	StatsdClient.Timing("request", requestDuration, tags, 1.0)
+	StatsdClient.Timing("request.duration", requestDuration, tags, 1.0)
 
 }

--- a/internal/auth/metrics_test.go
+++ b/internal/auth/metrics_test.go
@@ -163,7 +163,7 @@ func TestLogRequestMetrics(t *testing.T) {
 
 			client, _, _ := newTestStatsdClient(t)
 			tagString := strings.Join(tc.expectedTags, ",")
-			expectedPacketString := fmt.Sprintf("sso_auth.request:5.000000|ms|#%s", tagString)
+			expectedPacketString := fmt.Sprintf("sso_auth.request.duration:5.000000|ms|#%s", tagString)
 			// create a request with a url
 			// check metrics
 			req := httptest.NewRequest(tc.method, tc.requestURL, nil)

--- a/internal/proxy/metrics.go
+++ b/internal/proxy/metrics.go
@@ -63,6 +63,6 @@ func logRequestMetrics(req *http.Request, requestDuration time.Duration, status 
 	}
 
 	// TODO: eventually make rates configurable
-	StatsdClient.Timing("request", requestDuration, tags, 1.0)
+	StatsdClient.Timing("request.duration", requestDuration, tags, 1.0)
 
 }


### PR DESCRIPTION
## Problem
We send 'request' metrics in various places however they aren't all the same _type_ of metric, which makes things confusing while actually utilising the metrics unless the actual code is inspected.

For example: 

We send these 'request' metrics as time values:
https://github.com/buzzfeed/sso/blob/f302bca23e5b8b841dfb411d3d43df344772e6a6/internal/auth/metrics.go#L69

We send these 'provider.request' metrics as incremented values:
https://github.com/buzzfeed/sso/blob/521ff9c1529f7015d9cdc4d2a75832192535db18/internal/auth/providers/okta.go#L179


## Solution

Slightly rename the metrics that are of a `time` type so we can easily distinguish between the value types.

## Note

This could be classed as a 'breaking' change for anyone using this metric for reporting/monitoring purposes, however not for the actual functionality of SSO itself.

- This also now includes some test additions, largely ported over from the sso_auth metric tests.