### PR TITLE
ci: integrate with Codecov for test coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,4 @@
-version: 2.1
-orbs:
-  codecov: codecov/codecov@1.0.2
+version: 2
 jobs:
   build:
     docker:
@@ -29,11 +27,13 @@ jobs:
           command: |
             make dist/sso-proxy
       - run:
-            name: push sso-dev image
-            command: |
-              if [[ -n $DOCKER_USER ]]; then
-                docker login -u $DOCKER_USER -p $DOCKER_PASS
-                make imagepush
-              fi
-      - codecov/upload:
-          file: ./scripts/coverage.out
+          name: push sso-dev image
+          command: |
+            if [[ -n $DOCKER_USER ]]; then
+              docker login -u $DOCKER_USER -p $DOCKER_PASS
+              make imagepush
+            fi
+      - run:
+          name: upload coverage file to codecov
+          command: |
+            bash <(curl -s https://codecov.io/bash)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
-version: 2
+version: 2.1
+orbs:
+  codecov: codecov/codecov@1.0.2
 jobs:
   build:
     docker:
@@ -33,3 +35,5 @@ jobs:
                 docker login -u $DOCKER_USER -p $DOCKER_PASS
                 make imagepush
               fi
+      - codecov/upload:
+          file: ./scripts/coverage.out

--- a/.codecov/codecov.yml
+++ b/.codecov/codecov.yml
@@ -17,7 +17,7 @@ parsers:
       macro: no
 
 comment:
-  layout: "header, diff"
+  layout: "header, diff, files"
   behavior: default
   require_changes: no
 

--- a/.codecov/codecov.yml
+++ b/.codecov/codecov.yml
@@ -1,0 +1,23 @@
+coverage:
+  precision: 2
+  round: down
+  range: "50...80"
+
+  status:
+    project: yes
+    patch: yes
+    changes: no
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "header, diff"
+  behavior: default
+  require_changes: no
+

--- a/scripts/test
+++ b/scripts/test
@@ -32,4 +32,4 @@ go vet ./...
 
 echo "running tests ..."
 cd internal
-go test -cover -race ./... $@
+go test -coverprofile=coverage.out -race ./... $@


### PR DESCRIPTION
## Problem

We already try hard to make sure code has appropriate tests written, however we don't currently provide an easy way to monitor and track test coverage.

## Solution

Integrate the sso repo with a tool like [Codecov](https://codecov.io/), which helps us track and monitor coverage reports and make them a prominent part of pull requests and the contribution workflow.

## Notes

This currently uses the Codecov [bash uploader](https://docs.codecov.io/v4.3.0/docs/about-the-codecov-bash-uploader) to upload coverage reports, which is one of the recommended methods. Other methods include updating CircleCI to version 2.1 and making use of CircleCI [orbs](https://circleci.com/blog/making-code-coverage-easy-to-see-with-the-codecov-orb/).

Specific settings for codecov to be decided - this PR has been created with defaults.
