### PR TITLE
[auth] allow proxying root domains

### DIFF
--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -129,7 +129,7 @@ func validRedirectURI(uri string, rootDomains []string) bool {
 		return false
 	}
 	for _, domain := range rootDomains {
-		if strings.HasSuffix(redirectURL.Hostname(), domain) {
+		if strings.HasSuffix(redirectURL.Hostname(), domain) || redirectURL.Hostname() == strings.TrimLeft(domain, ".") {
 			return true
 		}
 	}

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -274,6 +274,12 @@ func TestValidateRedirectURI(t *testing.T) {
 			expectedStatusCode: http.StatusOK,
 			signatureSecret:    "clientSecret",
 		},
+		{
+			name:               "benign root hostname",
+			redirectURI:        "http://example.com",
+			expectedStatusCode: http.StatusOK,
+			signatureSecret:    "clientSecret",
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Problem

Currently, when users try to proxy requests to a root domain (i.e. not a subdomain of the root domain), they receive a 400 response (invalid redirect parameter). I would like to be able to serve content on my root domains in addition to the subdomains.

## Solution

Allow the literal root domain to be a valid redirect URI.
