### PR TITLE
ci: remove minimum coverage setting

### DIFF
--- a/.codecov/codecov.yml
+++ b/.codecov/codecov.yml
@@ -1,11 +1,21 @@
+# Codecov configuration file for this repo.
+# This file can be validated for syntax and layout issues using:
+#     cat codecov.yml | curl --data-binary @- https://codecov.io/validate
+# as per Codecov's documentation.
+
+
+# https://docs.codecov.io/docs/coverage-configuration
 coverage:
   precision: 2
   round: down
   range: "50...80"
 
+  # https://docs.codecov.io/docs/commit-status
   status:
-    project: yes
-    patch: yes
+    project:
+      default:
+        threshold: 2
+    patch: no
     changes: no
 
 parsers:
@@ -16,6 +26,7 @@ parsers:
       method: no
       macro: no
 
+# https://docs.codecov.io/docs/pull-request-comments
 comment:
   layout: "header, diff, files"
   behavior: default

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![CircleCI](https://circleci.com/gh/buzzfeed/sso.svg?style=svg)](https://circleci.com/gh/buzzfeed/sso)
 [![MIT license](http://img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
 [![Docker Automated build](https://img.shields.io/docker/automated/buzzfeed/sso.svg)](https://hub.docker.com/r/buzzfeed/sso/)
+[![codecov.io](https://codecov.io/github/buzzfeed/sso/coverage.svg?branch=master)](https://codecov.io/github/buzzfeed/sso?branch=master)
 
 
 <img src="https://user-images.githubusercontent.com/10510566/44476420-a64e5980-a605-11e8-8ad9-2820109deb75.png" width="128px">


### PR DESCRIPTION
## Problem

With the recent introduction of codecov, builds are failing to pass checks if their coverage falls below that of master.

## Solution

- Although we want to _increase_ coverage, I'm not sure if we want to set those hard limitations immediately?

    If I understand correctly these changes should remove the 'target', so we'll still get the PR comment but it won't fail due to coverage levels. 

- This also adds the codecov badge to our readme.