### PR TITLE
proxy: transition idps ux flow

### DIFF
--- a/internal/pkg/sessions/session_state.go
+++ b/internal/pkg/sessions/session_state.go
@@ -2,9 +2,6 @@ package sessions
 
 import (
 	"errors"
-	"fmt"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/buzzfeed/sso/internal/pkg/aead"
@@ -17,6 +14,9 @@ var (
 
 // SessionState is our object that keeps track of a user's session state
 type SessionState struct {
+	ProviderSlug string `json:"slug"`
+	ProviderType string `json:"type"`
+
 	AccessToken  string `json:"access_token"`
 	RefreshToken string `json:"refresh_token"`
 
@@ -72,27 +72,4 @@ func UnmarshalSession(value string, c aead.Cipher) (*SessionState, error) {
 // ExtendDeadline returns the time extended by a given duration
 func ExtendDeadline(ttl time.Duration) time.Time {
 	return time.Now().Add(ttl).Truncate(time.Second)
-}
-
-// NewSessionState creates a new session state
-// TODO: remove this file when we transition out of backup using the payloads encryption
-func NewSessionState(value string, lifetimeTTL time.Duration) (*SessionState, error) {
-	parts := strings.Split(value, "|")
-	if len(parts) != 4 {
-		err := fmt.Errorf("invalid number of fields (got %d expected 4)", len(parts))
-		return nil, err
-	}
-
-	ts, err := strconv.Atoi(parts[2])
-	if err != nil {
-		return nil, err
-	}
-
-	return &SessionState{
-		Email:            parts[0],
-		AccessToken:      parts[1],
-		RefreshDeadline:  time.Unix(int64(ts), 0),
-		RefreshToken:     parts[3],
-		LifetimeDeadline: ExtendDeadline(lifetimeTTL),
-	}, nil
 }

--- a/internal/pkg/sessions/session_state_test.go
+++ b/internal/pkg/sessions/session_state_test.go
@@ -16,6 +16,9 @@ func TestSessionStateSerialization(t *testing.T) {
 	}
 
 	want := &SessionState{
+		ProviderSlug: "slug",
+		ProviderType: "sso",
+
 		AccessToken:  "token1234",
 		RefreshToken: "refresh4321",
 

--- a/internal/proxy/oauthproxy_test.go
+++ b/internal/proxy/oauthproxy_test.go
@@ -625,6 +625,194 @@ func TestAuthenticate(t *testing.T) {
 	}
 }
 
+func TestAuthenticationUXFlows(t *testing.T) {
+	var (
+		ErrRefreshFailed = errors.New("refresh failed")
+		LoadCookieFailed = errors.New("load cookie fail")
+		SaveCookieFailed = errors.New("save cookie fail")
+	)
+	testCases := []struct {
+		Name string
+
+		SessionStore        *sessions.MockSessionStore
+		RefreshSessionFunc  func(*sessions.SessionState, []string) (bool, error)
+		ValidateSessionFunc func(*sessions.SessionState, []string) bool
+
+		ExpectStatusCode int
+	}{
+		{
+			Name: "missing deadlines, redirect to sign-in",
+			SessionStore: &sessions.MockSessionStore{
+				Session: &sessions.SessionState{
+					Email:       "email1@example.com",
+					AccessToken: "my_access_token",
+				},
+			},
+			ExpectStatusCode: http.StatusFound,
+		},
+		{
+			Name: "session unmarshaling fails, show error",
+			SessionStore: &sessions.MockSessionStore{
+				Session:   &sessions.SessionState{},
+				LoadError: LoadCookieFailed,
+			},
+			ExpectStatusCode: http.StatusInternalServerError,
+		},
+		{
+			Name: "authenticate successfully, expect ok",
+			SessionStore: &sessions.MockSessionStore{
+				Session: &sessions.SessionState{
+					Email:            "email1@example.com",
+					AccessToken:      "my_access_token",
+					LifetimeDeadline: time.Now().Add(time.Duration(24) * time.Hour),
+					RefreshDeadline:  time.Now().Add(time.Duration(1) * time.Hour),
+					ValidDeadline:    time.Now().Add(time.Duration(1) * time.Minute),
+				},
+			},
+			ExpectStatusCode: http.StatusOK,
+		},
+		{
+			Name: "lifetime expired, redirect to sign-in",
+			SessionStore: &sessions.MockSessionStore{
+				Session: &sessions.SessionState{
+					Email:            "email1@example.com",
+					AccessToken:      "my_access_token",
+					LifetimeDeadline: time.Now().Add(time.Duration(-24) * time.Hour),
+					RefreshDeadline:  time.Now().Add(time.Duration(1) * time.Hour),
+					ValidDeadline:    time.Now().Add(time.Duration(1) * time.Minute),
+				},
+			},
+			ExpectStatusCode: http.StatusFound,
+		},
+		{
+			Name: "refresh expired, refresh fails, show error",
+			SessionStore: &sessions.MockSessionStore{
+				Session: &sessions.SessionState{
+					Email:            "email1@example.com",
+					AccessToken:      "my_access_token",
+					LifetimeDeadline: time.Now().Add(time.Duration(24) * time.Hour),
+					RefreshDeadline:  time.Now().Add(time.Duration(-1) * time.Hour),
+					ValidDeadline:    time.Now().Add(time.Duration(1) * time.Minute),
+				},
+			},
+			RefreshSessionFunc: func(s *sessions.SessionState, g []string) (bool, error) { return false, ErrRefreshFailed },
+			ExpectStatusCode:   http.StatusInternalServerError,
+		},
+		{
+			Name: "refresh expired, user not OK, deny",
+			SessionStore: &sessions.MockSessionStore{
+				Session: &sessions.SessionState{
+					Email:            "email1@example.com",
+					AccessToken:      "my_access_token",
+					LifetimeDeadline: time.Now().Add(time.Duration(24) * time.Hour),
+					RefreshDeadline:  time.Now().Add(time.Duration(-1) * time.Hour),
+					ValidDeadline:    time.Now().Add(time.Duration(1) * time.Minute),
+				},
+			},
+			RefreshSessionFunc: func(s *sessions.SessionState, g []string) (bool, error) { return false, nil },
+			ExpectStatusCode:   http.StatusForbidden,
+		},
+		{
+			Name: "refresh expired, user OK, expect ok",
+			SessionStore: &sessions.MockSessionStore{
+				Session: &sessions.SessionState{
+					Email:            "email1@example.com",
+					AccessToken:      "my_access_token",
+					LifetimeDeadline: time.Now().Add(time.Duration(24) * time.Hour),
+					RefreshDeadline:  time.Now().Add(time.Duration(-1) * time.Hour),
+					ValidDeadline:    time.Now().Add(time.Duration(1) * time.Minute),
+				},
+			},
+			RefreshSessionFunc: func(s *sessions.SessionState, g []string) (bool, error) { return true, nil },
+			ExpectStatusCode:   http.StatusOK,
+		},
+		{
+			Name: "refresh expired, refresh and user OK, error saving session, show error",
+			SessionStore: &sessions.MockSessionStore{
+				Session: &sessions.SessionState{
+					Email:            "email1@example.com",
+					AccessToken:      "my_access_token",
+					LifetimeDeadline: time.Now().Add(time.Duration(24) * time.Hour),
+					RefreshDeadline:  time.Now().Add(time.Duration(-1) * time.Hour),
+					ValidDeadline:    time.Now().Add(time.Duration(1) * time.Minute),
+				},
+				SaveError: SaveCookieFailed,
+			},
+			RefreshSessionFunc: func(s *sessions.SessionState, g []string) (bool, error) { return true, nil },
+			ExpectStatusCode:   http.StatusInternalServerError,
+		},
+		{
+			Name: "validation expired, user not OK, deny",
+			SessionStore: &sessions.MockSessionStore{
+				Session: &sessions.SessionState{
+					Email:            "email1@example.com",
+					AccessToken:      "my_access_token",
+					LifetimeDeadline: time.Now().Add(time.Duration(24) * time.Hour),
+					RefreshDeadline:  time.Now().Add(time.Duration(1) * time.Hour),
+					ValidDeadline:    time.Now().Add(time.Duration(-1) * time.Minute),
+				},
+			},
+			ValidateSessionFunc: func(s *sessions.SessionState, g []string) bool { return false },
+			ExpectStatusCode:    http.StatusForbidden,
+		},
+		{
+			Name: "validation expired, user OK, expect ok",
+			SessionStore: &sessions.MockSessionStore{
+				Session: &sessions.SessionState{
+					Email:            "email1@example.com",
+					AccessToken:      "my_access_token",
+					LifetimeDeadline: time.Now().Add(time.Duration(24) * time.Hour),
+					RefreshDeadline:  time.Now().Add(time.Duration(1) * time.Hour),
+					ValidDeadline:    time.Now().Add(time.Duration(-1) * time.Minute),
+				},
+			},
+			ValidateSessionFunc: func(s *sessions.SessionState, g []string) bool { return true },
+			ExpectStatusCode:    http.StatusOK,
+		},
+		{
+			Name: "wrong identity provider, redirect to sign-in",
+			SessionStore: &sessions.MockSessionStore{
+				Session: &sessions.SessionState{
+					ProviderSlug:     "example",
+					Email:            "email1@example.com",
+					AccessToken:      "my_access_token",
+					LifetimeDeadline: time.Now().Add(time.Duration(24) * time.Hour),
+					RefreshDeadline:  time.Now().Add(time.Duration(1) * time.Hour),
+					ValidDeadline:    time.Now().Add(time.Duration(1) * time.Minute),
+				},
+			},
+			ExpectStatusCode: http.StatusFound,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			providerURL, _ := url.Parse("http://localhost/")
+			tp := providers.NewTestProvider(providerURL, "")
+			tp.RefreshSessionFunc = tc.RefreshSessionFunc
+			tp.ValidateSessionFunc = tc.ValidateSessionFunc
+
+			proxy, close := testNewOAuthProxy(t,
+				SetProvider(tp),
+				setSessionStore(tc.SessionStore),
+			)
+			defer close()
+
+			req := httptest.NewRequest("GET", "https://localhost", nil)
+			rw := httptest.NewRecorder()
+
+			proxy.Proxy(rw, req)
+
+			res := rw.Result()
+
+			if tc.ExpectStatusCode != res.StatusCode {
+				t.Errorf("have: %v", res.StatusCode)
+				t.Errorf("want: %v", tc.ExpectStatusCode)
+				t.Fatalf("expected status codes to be equal")
+			}
+		})
+	}
+}
+
 func TestProxyXHRErrorHandling(t *testing.T) {
 	testCases := []struct {
 		Name         string

--- a/internal/proxy/providers/sso.go
+++ b/internal/proxy/providers/sso.go
@@ -158,6 +158,9 @@ func (p *SSOProvider) Redeem(redirectURL, code string) (*sessions.SessionState, 
 
 	user := strings.Split(jsonResponse.Email, "@")[0]
 	return &sessions.SessionState{
+		ProviderSlug: p.ProviderData.ProviderSlug,
+		ProviderType: "sso",
+
 		AccessToken:  jsonResponse.AccessToken,
 		RefreshToken: jsonResponse.RefreshToken,
 


### PR DESCRIPTION
## Problem

If a user accesses an upstream for which the identity provider has changed, the user will get a very confusing and potentially concerning 500 Internal Server Error.  We can fix this ux flow so the user can be transparently authenticated with the new provider

## Solution

If a user is are already authenticated, we can transparently re-auth the user by clearing the existing cookie and restarting the authentication flow. If they aren't authenticated, this same process starts new auth flow at the authenticator.

## Notes

In order to make this work, we must add new fields to the session object which includes what provider slug/type information for the session. This adds some potential length to this cookie which is already starting to get big.
