### PR TITLE
ci: introduce circleci workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,16 +1,27 @@
+defaults: &defaults
+  docker:
+    - image: circleci/golang:1.11
+  working_directory: /go/src/github.com/buzzfeed/sso
+
+attach_workspace: &attach_workspace
+  attach_workspace:
+    at: /go/src/github.com/buzzfeed/sso
+
 version: 2
 jobs:
   build:
-    docker:
-      - image: circleci/golang:1.11
-    working_directory: /go/src/github.com/buzzfeed/sso
+    <<: *defaults
     steps:
+      - setup_remote_docker
+      - checkout
+      - persist_to_workspace:
+          root: /go/src/github.com/buzzfeed/sso
+          paths:
+            - .
       - run:
           name: Enable go modules
           command: |
             echo 'export GO111MODULE=on' >> $BASH_ENV
-      - checkout
-      - setup_remote_docker
       - run:
           name: get tools
           command: make tools
@@ -26,14 +37,59 @@ jobs:
           name: build sso-proxy
           command: |
             make dist/sso-proxy
+
+  push-sso-dev-commit:
+    <<: *defaults
+    steps:
+      - *attach_workspace
+      - setup_remote_docker
       - run:
-          name: push sso-dev image
+          name: push sso-dev commit tag
           command: |
             if [[ -n $DOCKER_USER ]]; then
               docker login -u $DOCKER_USER -p $DOCKER_PASS
-              make imagepush
+              make imagepush-commit
             fi
+
+  push-sso-dev-latest:
+    <<: *defaults
+    steps:
+      - *attach_workspace
+      - setup_remote_docker
+      - run:
+          name: push sso-dev latest tag
+          command: |
+            if [[ -n $DOCKER_USER ]]; then
+              docker login -u $DOCKER_USER -p $DOCKER_PASS
+              make imagepush-latest
+            fi
+
+  upload-codecov:
+    <<: *defaults
+    steps:
+      - *attach_workspace
       - run:
           name: upload coverage file to codecov
           command: |
             bash <(curl -s https://codecov.io/bash)
+
+
+workflows:
+  version: 2
+  build-and-push:
+    jobs:
+      - build
+      - push-sso-dev-commit:
+          requires:
+            - build
+      - push-sso-dev-latest:
+          requires:
+            - build
+          filters:
+            branches:
+              only: master
+      - upload-codecov:
+          requires:
+            - build
+
+

--- a/Makefile
+++ b/Makefile
@@ -25,12 +25,17 @@ test:
 clean:
 	rm -r dist
 
-imagepush:
+imagepush-commit:
 	docker build -t buzzfeed/sso-dev:$(commit) .
 	docker push buzzfeed/sso-dev:$(commit)
 
+imagepush-latest:
+	docker build -t buzzfeed/sso-dev:latest .
+	docker push buzzfeed/sso-dev:latest
+
 releasepush:
-	docker build -t buzzfeed/sso:$(version) .
+	docker build -t buzzfeed/sso:$(version) -t buzzfeed/sso-dev:latest .
 	docker push buzzfeed/sso:$(version)
+	docker push buzzfeed/sso:latest
 
 .PHONY: dist/sso-auth dist/sso-proxy tools


### PR DESCRIPTION
## Problem

There is currently no automation around tagging SSO docker images with the `latest` tag.

## Solution

This PR proposes moving our CircleCI config to use the ‘workflows’ method introduced in CircleCI `2.0`, allowing us to better separate and orchestrate individual jobs.

- Separates circleci jobs into logical ‘workflows’:
    - build
    - push-sso-dev-commit (only runs if build succeeded, and on each commit)
    - push-sso-dev-latest (only runs if build succeeeded, and only on master branch)
    - upload-codecov (only runs if build succeeded)

- Makefile tasks:
    - new `imagepush-latest` task (pushes with the `latest` tag)
    - changes `imagepush` to `imagepush-commit` to help separations for circleci
    - adds the `latest` tag to the image in the `releasepush` task.

## Notes
- We could also separate the build and test steps.
- We _can_ solve the problem statement without also moving to the workflows method, but this seemed like a logical advancement
 
Relevant issues: https://github.com/buzzfeed/sso/issues/193