### PR TITLE
ci: persist workspace further down the flow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,10 +14,6 @@ jobs:
     steps:
       - setup_remote_docker
       - checkout
-      - persist_to_workspace:
-          root: /go/src/github.com/buzzfeed/sso
-          paths:
-            - .
       - run:
           name: Enable go modules
           command: |
@@ -37,6 +33,10 @@ jobs:
           name: build sso-proxy
           command: |
             make dist/sso-proxy
+      - persist_to_workspace:
+          root: /go/src/github.com/buzzfeed/sso
+          paths:
+            - .
 
   push-sso-dev-commit:
     <<: *defaults


### PR DESCRIPTION
## Problem

With the introduction of circleci workflows, coverage reports were not being correctly found by the codecov script.

## Solution

We persist to workspace further down the flow, after the point in which the test coverage file is created. 

## Notes

The Codecov script appears to exit gracefully to avoid failing builds - we can alter this behaviour with `-Z`:

`-Z           Exit with 1 if not successful. Default will Exit with 0`
