### PR TITLE
Redis sessions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ require (
 	github.com/benbjohnson/clock v0.0.0-20161215174838-7dc76406b6d3
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/datadog/datadog-go v0.0.0-20180822151419-281ae9f2d895
+	github.com/go-redis/redis v6.15.2+incompatible
 	github.com/imdario/mergo v0.3.7
 	github.com/kelseyhightower/envconfig v1.3.0
 	github.com/mccutchen/go-httpbin v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-playground/locales v0.12.1/go.mod h1:IUMDtCfWo/w/mtMfIE/IG2K+Ey3ygWanZIBtBW0W2TM=
 github.com/go-playground/universal-translator v0.16.0/go.mod h1:1AnU7NaIRDWWzGEKwgtJRd2xk99HeFyHw3yid4rvQIY=
+github.com/go-redis/redis v6.15.2+incompatible h1:9SpNVG76gr6InJGxoZ6IuuxaCOQwDAhzyXg+Bs+0Sb4=
+github.com/go-redis/redis v6.15.2+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
 github.com/go-redsync/redsync v1.2.0/go.mod h1:QClK/s99KRhfKdpxLTMsI5mSu43iLp0NfOneLPie+78=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=

--- a/internal/auth/configuration_test.go
+++ b/internal/auth/configuration_test.go
@@ -131,6 +131,57 @@ func TestEnvironmentOverridesConfiguration(t *testing.T) {
 			},
 		},
 		{
+			Name: "Test Sessions",
+			EnvOverrides: map[string]string{
+				"SESSION_LIFETIME": "1h",
+				"SESSION_KEY":      "abcdefg",
+			},
+			CheckFunc: func(c Configuration, t *testing.T) {
+				assertEq(1*time.Hour, c.SessionConfig.SessionLifetimeTTL, t)
+				assertEq("abcdefg", c.SessionConfig.Key, t)
+			},
+		},
+		{
+			Name: "Test Redis Sessions",
+			EnvOverrides: map[string]string{
+				"SESSION_REDIS_CONNECTION": "redis://master.example.com:6379",
+			},
+			CheckFunc: func(c Configuration, t *testing.T) {
+				redisConf := c.SessionConfig.RedisConfig
+				assertEq([]string{"redis://master.example.com:6379"}, redisConf.ConnectionURLs, t)
+			},
+		},
+		{
+			Name: "Test Redis Sentinel Sessions",
+			EnvOverrides: map[string]string{
+				"SESSION_REDIS_SENTINEL":   "true",
+				"SESSION_REDIS_MASTER":     "redis://master.example.com:6379",
+				"SESSION_REDIS_CONNECTION": "redis://instance-001.example.com:6379,redis://instance-002.example.com:6379,redis://instance-003.example.com:6379",
+			},
+			CheckFunc: func(c Configuration, t *testing.T) {
+				redisConf := c.SessionConfig.RedisConfig
+				assertEq(true, redisConf.UseSentinel, t)
+				assertEq("redis://master.example.com:6379", redisConf.SentinelMasterName, t)
+				assertEq([]string{
+					"redis://instance-001.example.com:6379",
+					"redis://instance-002.example.com:6379",
+					"redis://instance-003.example.com:6379",
+				}, redisConf.ConnectionURLs, t)
+			},
+		},
+		{
+			Name: "Test Cookie Sessions",
+			EnvOverrides: map[string]string{
+				"SESSION_COOKIE_NAME":   "sso_auth_test",
+				"SESSION_COOKIE_SECRET": "s3kr1t",
+			},
+			CheckFunc: func(c Configuration, t *testing.T) {
+				cookieConf := c.SessionConfig.CookieConfig
+				assertEq("sso_auth_test", cookieConf.Name, t)
+				assertEq("s3kr1t", cookieConf.Secret, t)
+			},
+		},
+		{
 			Name: "Test Multiple Providers",
 			EnvOverrides: map[string]string{
 				// foo

--- a/internal/auth/options.go
+++ b/internal/auth/options.go
@@ -149,3 +149,56 @@ func SetCookieStore(sessionConfig SessionConfig, providerSlug string) func(*Auth
 		return nil
 	}
 }
+
+// SetRedisStore sets the session store to use redis
+func SetRedisStore(sessionConfig SessionConfig, providerSlug string) func(*Authenticator) error {
+	return func(a *Authenticator) error {
+		decodedKey, err := base64.StdEncoding.DecodeString(sessionConfig.Key)
+		if err != nil {
+			return err
+		}
+
+		codeCipher, err := aead.NewMiscreantCipher([]byte(decodedKey))
+		if err != nil {
+			return err
+		}
+
+		cc := sessionConfig.CookieConfig
+		rc := sessionConfig.RedisConfig
+		decodedCookieSecret, err := base64.StdEncoding.DecodeString(cc.Secret)
+		if err != nil {
+			return err
+		}
+
+		cookieName := fmt.Sprintf("%s_%s", cc.Name, providerSlug)
+		redisStore, err := sessions.NewRedisStore(cookieName,
+			func(c *sessions.RedisStore) error {
+				return sessions.CreateMiscreantCookieCipher(decodedCookieSecret)(&c.CookieStore)
+			},
+			func(c *sessions.RedisStore) error {
+				if rc.UseSentinel {
+					c.UseSentinel = rc.UseSentinel
+					c.SentinelMasterName = rc.SentinelMasterName
+					c.SentinelConnectionURLs = rc.ConnectionURLs
+				} else {
+					c.UseSentinel = rc.UseSentinel
+					c.ConnectionURL = rc.ConnectionURLs[0]
+				}
+
+				c.CookieDomain = cc.Domain
+				c.CookieHTTPOnly = cc.HTTPOnly
+				c.CookieExpire = cc.Expire
+				c.CookieSecure = cc.Secure
+				return nil
+			})
+
+		if err != nil {
+			return err
+		}
+
+		a.csrfStore = redisStore
+		a.sessionStore = redisStore
+		a.AuthCodeCipher = codeCipher
+		return nil
+	}
+}

--- a/internal/pkg/sessions/redis_store.go
+++ b/internal/pkg/sessions/redis_store.go
@@ -16,7 +16,7 @@ import (
 type RedisStore struct {
 	CookieStore
 	CreatedAt              time.Time
-	RedisConnectionURL     string
+	ConnectionURL          string
 	UseSentinel            bool
 	SentinelMasterName     string
 	SentinelConnectionURLs []string
@@ -47,7 +47,7 @@ func NewRedisStore(cookieName string, optFuncs ...func(*RedisStore) error) (*Red
 			return nil, errors.New("must provide redis connection url or sentinel config")
 		}
 	} else {
-		if r.RedisConnectionURL == "" {
+		if r.ConnectionURL == "" {
 			return nil, errors.New("must provide redis connection url or sentinel config")
 		}
 	}
@@ -70,7 +70,7 @@ func (r *RedisStore) initRedisClient() error {
 		return nil
 	}
 
-	opt, err := redis.ParseURL(r.RedisConnectionURL)
+	opt, err := redis.ParseURL(r.ConnectionURL)
 	if err != nil {
 		return fmt.Errorf("unable to parse redis url: %s", err)
 	}

--- a/internal/pkg/sessions/redis_store.go
+++ b/internal/pkg/sessions/redis_store.go
@@ -1,0 +1,48 @@
+package sessions
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// RedisStore represents all the cookie related configurations
+type RedisStore struct {
+	CookieStore
+	RedisConnectionURL     string
+	UseSentinel            bool
+	SentinelMasterName     string
+	SentinelConnectionURLs []string
+}
+
+// NewRedisStore returns a new session
+func NewRedisStore(cookieName string, optFuncs ...func(*RedisStore) error) (*RedisStore, error) {
+	r := &RedisStore{
+		CookieStore: CookieStore{
+			Name:           cookieName,
+			CookieSecure:   true,
+			CookieHTTPOnly: true,
+			CookieExpire:   168 * time.Hour,
+			CSRFCookieName: fmt.Sprintf("%v_%v", cookieName, "csrf"),
+		},
+	}
+
+	for _, f := range optFuncs {
+		err := f(r)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if r.UseSentinel {
+		if r.SentinelMasterName == "" || len(r.SentinelConnectionURLs) == 0 {
+			return nil, errors.New("must provide redis connection url or sentinel config")
+		}
+	} else {
+		if r.RedisConnectionURL == "" {
+			return nil, errors.New("must provide redis connection url or sentinel config")
+		}
+	}
+
+	return r, nil
+}

--- a/internal/pkg/sessions/redis_store.go
+++ b/internal/pkg/sessions/redis_store.go
@@ -1,22 +1,21 @@
 package sessions
 
 import (
+	"crypto/rand"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
 	"time"
 
+	log "github.com/buzzfeed/sso/internal/pkg/logging"
 	"github.com/go-redis/redis"
 )
-
-// TicketData is a structure representing the ticket used in server session storage
-type TicketData struct {
-	TicketID string
-	Secret   []byte
-}
 
 // RedisStore represents all the cookie related configurations
 type RedisStore struct {
 	CookieStore
+	CreatedAt              time.Time
 	RedisConnectionURL     string
 	UseSentinel            bool
 	SentinelMasterName     string
@@ -77,5 +76,67 @@ func (r *RedisStore) initRedisClient() error {
 	}
 
 	r.client = redis.NewClient(opt)
+	return nil
+}
+
+// ClearSession clears the session cookie from a request
+func (r *RedisStore) ClearSession(rw http.ResponseWriter, req *http.Request) {
+	tokenCookie, err := req.Cookie(r.CookieStore.Name)
+	if err == nil && tokenCookie.Value != "" {
+		logger := log.NewLogEntry()
+		err = r.client.Del(tokenCookie.Value).Err()
+		if err != nil {
+			logger.WithRequestHost(req.Host).WithError(err).Error("ignoring error clearing session")
+		}
+	}
+	r.CookieStore.ClearSession(rw, req)
+}
+
+// LoadSession returns a SessionState from the Redis session store.
+func (r *RedisStore) LoadSession(req *http.Request) (*SessionState, error) {
+	logger := log.NewLogEntry()
+	tokenCookie, err := req.Cookie(r.CookieStore.Name)
+	if err != nil {
+		// always http.ErrNoCookie
+		return nil, err
+	}
+
+	result, err := r.client.Get(tokenCookie.Value).Result()
+	if err != nil {
+		logger.WithRequestHost(req.Host).WithError(err).Error("error retrieving session")
+		return nil, err
+	}
+
+	session, err := UnmarshalSession(result, r.CookieStore.CookieCipher)
+	if err != nil {
+		logger.WithRequestHost(req.Host).WithError(err).Error("error unmarshaling session")
+		return nil, ErrInvalidSession
+	}
+	return session, nil
+}
+
+// SaveSession saves a session state to the Redis session store.
+func (r *RedisStore) SaveSession(rw http.ResponseWriter, req *http.Request, sessionState *SessionState) error {
+	// Lack of a cookie is expected for new sessions, discard any errors.
+	tokenCookie, _ := req.Cookie(r.CookieStore.Name)
+	if tokenCookie == nil || tokenCookie.Value == "" {
+		tokenRaw := make([]byte, 32)
+		if _, err := io.ReadFull(rand.Reader, tokenRaw); err != nil {
+			return fmt.Errorf("failed to create initialization vector %s", err)
+		}
+		token := fmt.Sprintf("%x", tokenRaw)
+		tokenCookie = r.makeSessionCookie(req, token, r.CookieStore.CookieExpire, time.Now())
+		http.SetCookie(rw, tokenCookie)
+	}
+
+	value, err := MarshalSession(sessionState, r.CookieStore.CookieCipher)
+	if err != nil {
+		return err
+	}
+
+	err = r.client.Set(tokenCookie.Value, value, r.CookieStore.SessionLifetimeTTL).Err()
+	if err != nil {
+		return err
+	}
 	return nil
 }

--- a/internal/pkg/sessions/redis_store_test.go
+++ b/internal/pkg/sessions/redis_store_test.go
@@ -30,13 +30,13 @@ func TestNewRedisSession(t *testing.T) {
 		{
 			name: "opt func overrides default values",
 			optFuncs: []func(*RedisStore) error{func(s *RedisStore) error {
-				s.RedisConnectionURL = "redis://localhost:6379/"
+				s.ConnectionURL = "redis://localhost:6379/"
 				s.CookieExpire = time.Hour
 				return nil
 			}},
 			expectedClient: true,
 			expectedSession: &RedisStore{
-				RedisConnectionURL: "redis://localhost:6379/",
+				ConnectionURL: "redis://localhost:6379/",
 				CookieStore: CookieStore{
 					Name:           "cookieName",
 					CookieSecure:   true,

--- a/internal/pkg/sessions/redis_store_test.go
+++ b/internal/pkg/sessions/redis_store_test.go
@@ -1,0 +1,58 @@
+package sessions
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/buzzfeed/sso/internal/pkg/testutil"
+)
+
+func TestNewRedisSession(t *testing.T) {
+	testCases := []struct {
+		name            string
+		optFuncs        []func(*RedisStore) error
+		expectedError   bool
+		expectedSession *RedisStore
+	}{
+		{
+			name:          "default with no opt funcs set",
+			expectedError: true,
+		},
+		{
+			name:          "opt func with an error returns an error",
+			optFuncs:      []func(*RedisStore) error{func(*RedisStore) error { return fmt.Errorf("error") }},
+			expectedError: true,
+		},
+		{
+			name: "opt func overrides default values",
+			optFuncs: []func(*RedisStore) error{func(s *RedisStore) error {
+				s.RedisConnectionURL = "redis://localhost:6379/"
+				s.CookieExpire = time.Hour
+				return nil
+			}},
+			expectedSession: &RedisStore{
+				RedisConnectionURL: "redis://localhost:6379/",
+				CookieStore: CookieStore{
+					Name:           "cookieName",
+					CookieSecure:   true,
+					CookieHTTPOnly: true,
+					CookieExpire:   time.Hour,
+					CSRFCookieName: "cookieName_csrf",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			session, err := NewRedisStore("cookieName", tc.optFuncs...)
+			if tc.expectedError {
+				testutil.NotEqual(t, err, nil)
+			} else {
+				testutil.Ok(t, err)
+			}
+			testutil.Equal(t, tc.expectedSession, session)
+		})
+	}
+}

--- a/internal/proxy/oauthproxy.go
+++ b/internal/proxy/oauthproxy.go
@@ -103,6 +103,33 @@ func SetCookieStore(opts *Options) func(*OAuthProxy) error {
 	}
 }
 
+// SetRedisStore sets the session and csrf stores as a functional option
+func SetRedisStore(opts *Options) func(*OAuthProxy) error {
+	return func(op *OAuthProxy) error {
+		redisStore, err := sessions.NewRedisStore(opts.CookieName,
+			func(c *sessions.RedisStore) error {
+				c.RedisConnectionURL = opts.RedisConnectionURL
+				c.UseSentinel = opts.RedisUseSentinel
+				c.SentinelMasterName = opts.RedisSentinelMasterName
+				c.SentinelConnectionURLs = opts.RedisSentinelConnectionURLs
+
+				c.CookieDomain = opts.CookieDomain
+				c.CookieHTTPOnly = opts.CookieHTTPOnly
+				c.CookieExpire = opts.CookieExpire
+				c.CookieSecure = opts.CookieSecure
+				return nil
+			})
+
+		if err != nil {
+			return err
+		}
+
+		op.csrfStore = redisStore
+		op.sessionStore = redisStore
+		return nil
+	}
+}
+
 // SetRequestSigner sets the request signer  as a functional option
 // SetRequestSigner sets a request signer
 func SetRequestSigner(signer *RequestSigner) func(*OAuthProxy) error {

--- a/internal/proxy/oauthproxy.go
+++ b/internal/proxy/oauthproxy.go
@@ -108,6 +108,9 @@ func SetRedisStore(opts *Options) func(*OAuthProxy) error {
 	return func(op *OAuthProxy) error {
 		redisStore, err := sessions.NewRedisStore(opts.CookieName,
 			func(c *sessions.RedisStore) error {
+				return sessions.CreateMiscreantCookieCipher(opts.decodedCookieSecret)(&c.CookieStore)
+			},
+			func(c *sessions.RedisStore) error {
 				c.RedisConnectionURL = opts.RedisConnectionURL
 				c.UseSentinel = opts.RedisUseSentinel
 				c.SentinelMasterName = opts.RedisSentinelMasterName

--- a/internal/proxy/oauthproxy.go
+++ b/internal/proxy/oauthproxy.go
@@ -111,7 +111,7 @@ func SetRedisStore(opts *Options) func(*OAuthProxy) error {
 				return sessions.CreateMiscreantCookieCipher(opts.decodedCookieSecret)(&c.CookieStore)
 			},
 			func(c *sessions.RedisStore) error {
-				c.RedisConnectionURL = opts.RedisConnectionURL
+				c.ConnectionURL = opts.RedisConnectionURL
 				c.UseSentinel = opts.RedisUseSentinel
 				c.SentinelMasterName = opts.RedisSentinelMasterName
 				c.SentinelConnectionURLs = opts.RedisSentinelConnectionURLs
@@ -129,6 +129,7 @@ func SetRedisStore(opts *Options) func(*OAuthProxy) error {
 
 		op.csrfStore = redisStore
 		op.sessionStore = redisStore
+		op.cookieCipher = redisStore.CookieCipher
 		return nil
 	}
 }

--- a/internal/proxy/options.go
+++ b/internal/proxy/options.go
@@ -80,6 +80,11 @@ type Options struct {
 	CookieSecure   bool          `envconfig:"COOKIE_SECURE" default:"true"`
 	CookieHTTPOnly bool          `envconfig:"COOKIE_HTTP_ONLY"`
 
+	RedisConnectionURL          string   `envconfig:"REDIS_CONNECTION_URL"`
+	RedisUseSentinel            bool     `envconfig:"REDIS_USE_SENTINEL"`
+	RedisSentinelMasterName     string   `envconfig:"REDIS_SENTINEL_MASTER_NAME"`
+	RedisSentinelConnectionURLs []string `envconfig:"REDIS_SENTINEL_CONNECTION_URLS"`
+
 	PassAccessToken bool `envconfig:"PASS_ACCESS_TOKEN" default:"false"`
 
 	Provider            string `envconfig:"PROVIDER" default:"sso"`

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -43,9 +43,13 @@ func New(opts *Options) (*SSOProxy, error) {
 			return nil, err
 		}
 
+		setSessionStore := SetCookieStore
+		if opts.RedisConnectionURL != "" || opts.RedisUseSentinel {
+			setSessionStore = SetRedisStore
+		}
 		optFuncs = append(optFuncs,
 			SetProvider(provider),
-			SetCookieStore(opts),
+			setSessionStore(opts),
 			SetUpstreamConfig(upstreamConfig),
 			SetProxyHandler(handler),
 		)


### PR DESCRIPTION
## Problem

Session state can become quite large and can easily exceed the maximum cookie size. I previously tried to fix it with #150 but that proved to be a bad solution prone to failures.

## Solution

This introduces optional support for a Redis backend for sessions. Setting a `SESSION_REDIS_CONNECTION` environment variable to e.g. `redis://primary.sso-sessions.example-cloud.com:6379` will switch the session backend from cookie sessions to redis sessions. The default remains cookie sessions.

## Notes

This also avoids the issue of large amounts of session state being retransmitted on every request. Session state is encrypted using the existing cipher mechanism and session keys. As discussed in #158, I recommend renaming the cipher key configuration name to be more generic, but this PR doesn't make that change. This PR does not use the ticket system mentioned in #158, and instead opts for the simpler approach of encrypting using the session secret held on the auth server. I have tested this PR in conjunction with #118 and it works well.