### PR TITLE
docker: build from go 1.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #
 # install golang dependencies & build binaries
 # =============================================================================
-FROM golang:1.11 AS build
+FROM golang:1.12 AS build
 
 ENV GOFLAGS='-ldflags=-s -ldflags=-w'
 ENV CGO_ENABLED=0


### PR DESCRIPTION
## Problem

`httputil.ReverseProxy` doesn't support WebSockets in go 1.11.

## Solution

Build binaries using go 1.12.

## Notes

I'm not sure if any additional changes are required to get WebSockets to work, but this is a start.

https://github.com/buzzfeed/sso/issues/103
https://go-review.googlesource.com/c/go/+/146437