### PR TITLE
sso quickstart/docs: update configuration variables

### DIFF
--- a/docs/google_provider_setup.md
+++ b/docs/google_provider_setup.md
@@ -43,8 +43,8 @@ asked to fill in three fields.
 - **Name**: Any appropriate name is fine (e.g. `Dev`).
 - **Authorized JavaScript origins**: Leave this field blank.
 - **Authorized redirect URIs**: Add the URI of your `sso-auth` deployment, with the path suffix
-`/oauth2/callback`. For example, if `sso-auth` will  be accessible at the domain
-`sso-auth.example.com`, then add the URI `https://sso-auth.example.com/oauth2/callback`.
+`/google/callback`. For example, if `sso-auth` will  be accessible at the domain
+`sso-auth.example.com`, then add the URI `https://sso-auth.example.com/google/callback`.
 
 **⚡️ Note:** If you're following the [Quickstart guide](quickstart.md), use
 `http://sso-auth.localtest.me` as the Authorized redirect URI.
@@ -122,7 +122,12 @@ have been filled in, click the "Authorize" button.
 To give `sso-auth` permission to access Google Group information for users, the following
 environment variables must be set:
 
-- **`GOOGLE_ADMIN_EMAIL`**: An administrative email address on your organization's
+NOTE: `GOOGLEQUICKSTART` is a logical identifier that is used to group the configuration
+variables together for any one provider. This can be changed to an identifier that makes
+sense for your individual use case.
+If following the quickstart, make sure this identifier matches what you used there.
+
+- **`PROVIDER_GOOGLEQUICKSTART_GOOGLE_IMPERSONATE`**: An administrative email address on your organization's
 domain, the identity of which can be assumed by `sso`.
 - **`GOOGLE_SERVICE_ACCOUNT_JSON`**: The path to the JSON file downloaded at the time of
 service account creation above. There is no reason why this file should ever be accessed by any

--- a/docs/okta_provider_setup.md
+++ b/docs/okta_provider_setup.md
@@ -44,9 +44,9 @@ Select the 'Applications' dropdown and then 'Applications'. Click 'Add Applicati
 For 'Platform', choose `Web`, and for 'Sign on method' choose `OpenID Connect`. You will be asked to fill in some fields:
 - **Application Name**: Any appropriate name.
 -  **Application Logo**: Optional - an image for your app.
--  **Login redirect URIs**: Add the URI of your `sso-auth` deployment, with the path suffix `/oauth2/callback`.
+-  **Login redirect URIs**: Add the URI of your `sso-auth` deployment, with the path suffix `/okta/callback`.
     For example, if `sso-auth` will be accessible at the domain `sso-auth.example.com`, then add the URI
-    `https://sso-auth.example.com/oauth2/callback`. Multiple URIs can be added if required.
+    `https://sso-auth.example.com/okta/callback`. Multiple URIs can be added if required.
 -  **Logout redirect URIs**: This can be left blank.
 
 **⚡️ Note**: If you're following the [Quickstart guide](https://github.com/buzzfeed/sso/blob/master/docs/quickstart.md), use `http://sso-auth.localtest.me` as the Authorized redirect URI.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -33,14 +33,26 @@ section below:
 Follow steps 1 and 2 of the [Google Provider Setup](google_provider_setup.md)
 documentation.
 
-**⚡️ Note:** Use `http://sso-auth.localtest.me/oauth2/callback` as the
+**⚡️ Note:** Use `http://sso-auth.localtest.me/google/callback` as the
 **Authorized redirect URI** in step 2.
 
 At the end of step 2, you will have a client ID and client secret. Create a new
-file called `env` with those values, like so:
+file called `env` and input those values like so:
 
-    CLIENT_ID=<client id value>.apps.googleusercontent.com
-    CLIENT_SECRET=<client secret value>
+NOTE: `GOOGLEQUICKSTART` is a logical identifier that is used to group the configuration
+variables together for any one provider. This can be changed to an identifier that makes
+sense for your individual use case.
+
+    PROVIDER_GOOGLEQUICKSTART_CLIENT_ID=<client id value>.apps.googleusercontent.com
+    PROVIDER_GOOGLEQUICKSTART_CLIENT_SECRET=<client secret value>
+
+As well as these, you also need to give a provider 'slug' for the configuration of the
+provider http routes.
+
+Add the below lines into the `env` file you just created:
+
+    PROVIDER_GOOGLEQUICKSTART_TYPE=google
+    PROVIDER_GOOGLEQUICKSTART_SLUG=google
 
 This file will be used to configure `sso-auth` in the example deployment to
 allow you to log to **sso**.
@@ -58,15 +70,23 @@ At the end of step 3 you will be given a client ID and client secret which can b
 of the settings page for the Application you've created.
 Create a new file called `env` with those values, like so:
 
-    CLIENT_ID=<client id value>
-    CLIENT_SECRET=<client secret value>
+NOTE: `OKTAQUICKSTART` is a logical identifier that is used to group the configuration
+variables together for any one provider. This can be changed to an identifier that makes
+sense for your individual use case.
+
+    PROVIDER_OKTAQUICKSTART_CLIENT_ID=<client id value>
+    PROVIDER_OKTAQUICKSTART_CLIENT_SECRET=<client secret value>
 
 As well as these, you also need to make sure **sso** knows to use the 'Okta' provider
-(Okta is not the default provider) and provide your Okta organisation URL (for example, 'sso-test.okta.com')
+(Okta is not the default provider), provide your Okta organisation URL (for example, 'sso-test.okta.com'),
+and give a provider 'slug' for the configuration of http routes.
+
 Add the below lines into the `env` file you just created:
 
-    PROVIDER="okta"
-    OKTA_ORG_URL=<organisation url>
+    DEFAULT_PROVIDER_SLUG=okta
+    PROVIDER_OKTAQUICKSTART_OKTA_URL=<organisation url>
+    PROVIDER_OKTAQUICKSTART_TYPE=okta
+    PROVIDER_OKTAQUICKSTART_SLUG=okta
 
 If you are not using the default Okta authorization server you will also need to add `PROVIDER_SERVER_ID=<okta auth server ID>`
 to the above file.

--- a/quickstart/docker-compose.yml
+++ b/quickstart/docker-compose.yml
@@ -70,35 +70,36 @@ services:
       ./env
     environment:
       # Allow any google account to log in for demo purposes
-      - SSO_EMAIL_DOMAIN=*
+      - AUTHORIZE_EMAIL_DOMAINS=*
 
-      # (Optional) Allow specific google email address to log in for demo purposes
-      # This overrides SSO_EMAIL_DOMAIN
-      # - SSO_EMAIL_ADDRESSES=*
+      # (Optional) Allow specific email address to log in for demo purposes
+      # This overrides AUTHORIZE_EMAIL_DOMAINS
+      # - AUTHORIZE_EMAIL_ADDRESSES=*
 
-      - HOST=sso-auth.localtest.me
-      - REDIRECT_URL=http://sso-auth.localtest.me
-      - PROXY_ROOT_DOMAIN=localtest.me
+      - AUTHORIZE_PROXY_DOMAINS=localtest.me
+
+      - SERVER_SCHEME=http
+      - SERVER_HOST=sso-auth.localtest.me
 
       # These values must match sso-proxy's CLIENT_ID and CLIENT_SECRET values
-      - PROXY_CLIENT_ID=aGNHd3FqWUVDb1Z0NVFVZDE4Vk8xbWhQeVdoc3pjMnU=
-      - PROXY_CLIENT_SECRET=aDducXQzK2tPY3R4TmdqTGhaYS80eGYxcTUvWWJDb2M=
+      - CLIENT_PROXY_ID=aGNHd3FqWUVDb1Z0NVFVZDE4Vk8xbWhQeVdoc3pjMnU=
+      - CLIENT_PROXY_SECRET=aDducXQzK2tPY3R4TmdqTGhaYS80eGYxcTUvWWJDb2M=
 
       # XXX: These secrets are for demonstration purposes only! Use
       #
       #     openssl rand -base64 32
       #
       # to generate your own.
-      - AUTH_CODE_SECRET=c1kxTHcyN3FwdGRiZHpZRU15TUpNdFlpb1ZEUUw5R3M=
-      - COOKIE_SECRET=V2JBZk0zWGtsL29UcFUvWjVDWWQ2UHExNXJ0b2VhcDI=
+      - SESSION_KEY=c1kxTHcyN3FwdGRiZHpZRU15TUpNdFlpb1ZEUUw5R3M=
+      - SESSION_COOKIE_SECRET=V2JBZk0zWGtsL29UcFUvWjVDWWQ2UHExNXJ0b2VhcDI=
 
       # Disable https for demo purposes
-      - COOKIE_SECURE=false
+      - SESSION_COOKIE_SECURE=false
 
       # TODO: these config values should probably have defaults
       - CLUSTER=dev
-      - STATSD_HOST=127.0.0.1
-      - STATSD_PORT=8125
+      - METRICS_STATSD_HOST=127.0.0.1
+      - METRICS_STATSD_PORT=8125
 
       # Tells nginx-proxy service how to route requests to this service
       - VIRTUAL_HOST=sso-auth.localtest.me,host.docker.internal


### PR DESCRIPTION
## Problem

We’ve made some substantial changes to the configuration variables (largely their names, but also what’s optional) required by SSO. This means that the quickstart and other documentation is outdated.

## Solution

This PR pulls our various documentation back in line with the configuration variables we now use. Most changes are applicable only to the ‘auth’ portion of SSO; the ‘proxy’ configuration variables have not yet been fully updated.
