### PR TITLE
Relax the use of Email Domains/Addresses to enforce authentication

### DIFF
--- a/docs/sso_config.md
+++ b/docs/sso_config.md
@@ -30,7 +30,9 @@ For example, the following config would have the following environment variables
   * **to** is the cname of the proxied service (this tells sso proxy where to proxy requests that come in on the from field)
   * **type** declares the type of route to use, right now there is just *simple* and *rewrite*.
   * **options** are a set of options that can be added to your configuration.
-    * **allowed groups** optional list of authorized google groups that can access the service. If not specified, anyone within an email domain is allowed to access the service. *Note*: We do not support nested group authentication at this time. Groups must be made up of email addresses associated with individual's accounts. See [#133](https://github.com/buzzfeed/sso/issues/133).
+    * **allowed groups** optional list of authorized google groups that can access the service.
+    * **allowed_email_domains** options list of authorized email domains that can access the service.
+    * **allowed_email_addresses** optional list of authorized email addresses that can access the service.
     * **skip_auth_regex** skips authentication for paths matching these regular expressions. NOTE: Use with extreme caution.
     * **header_overrides** overrides any heads set either by SSO proxy itself or upstream applications. Useful for modifying browser security headers.
     * **timeout** sets the amount of time that SSO Proxy will wait for the upstream to complete its request.

--- a/internal/auth/configuration.go
+++ b/internal/auth/configuration.go
@@ -99,10 +99,6 @@ func DefaultAuthConfig() Configuration {
 		},
 		// we provide no defaults for these right now
 		AuthorizeConfig: AuthorizeConfig{
-			EmailConfig: EmailConfig{
-				Domains:   []string{},
-				Addresses: []string{},
-			},
 			ProxyConfig: ProxyConfig{
 				Domains: []string{},
 			},
@@ -120,7 +116,6 @@ var (
 	_ Validator = ProviderConfig{}
 	_ Validator = ClientConfig{}
 	_ Validator = AuthorizeConfig{}
-	_ Validator = EmailConfig{}
 	_ Validator = ProxyConfig{}
 	_ Validator = ServerConfig{}
 	_ Validator = MetricsConfig{}
@@ -402,34 +397,12 @@ func (cc ClientConfig) Validate() error {
 }
 
 type AuthorizeConfig struct {
-	EmailConfig EmailConfig `mapstructure:"email"`
 	ProxyConfig ProxyConfig `mapstructure:"proxy"`
 }
 
 func (ac AuthorizeConfig) Validate() error {
-	if err := ac.EmailConfig.Validate(); err != nil {
-		return xerrors.Errorf("invalid authorize.email config: %w", err)
-	}
-
 	if err := ac.ProxyConfig.Validate(); err != nil {
 		return xerrors.Errorf("invalid authorize.proxy config: %w", err)
-	}
-
-	return nil
-}
-
-type EmailConfig struct {
-	Domains   []string `mapstructure:"domains"`
-	Addresses []string `mapstructure:"addresses"`
-}
-
-func (ec EmailConfig) Validate() error {
-	if len(ec.Domains) > 0 && len(ec.Addresses) > 0 {
-		return xerrors.New("can not specify both email.domains and email.addesses")
-	}
-
-	if len(ec.Domains) == 0 && len(ec.Addresses) == 0 {
-		return xerrors.New("must specify either email.domains or email.addresses")
 	}
 
 	return nil

--- a/internal/auth/configuration_test.go
+++ b/internal/auth/configuration_test.go
@@ -61,9 +61,6 @@ func testConfiguration(t *testing.T) Configuration {
 			ProxyConfig: ProxyConfig{
 				Domains: []string{"proxy.local", "root.local", "example.com"},
 			},
-			EmailConfig: EmailConfig{
-				Domains: []string{"proxy.local"},
-			},
 		},
 	}
 	err := c.Validate()
@@ -163,15 +160,6 @@ func TestEnvironmentOverridesConfiguration(t *testing.T) {
 				assertEq("baz-client-id", baz.ClientConfig.ID, t)
 			},
 		},
-		{
-			Name: "Test ENV CSV Lists",
-			EnvOverrides: map[string]string{
-				"AUTHORIZE_EMAIL_DOMAINS": "proxy.local,root.local",
-			},
-			CheckFunc: func(c Configuration, t *testing.T) {
-				assertEq([]string{"proxy.local", "root.local"}, c.AuthorizeConfig.EmailConfig.Domains, t)
-			},
-		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
@@ -246,9 +234,6 @@ func TestConfigValidate(t *testing.T) {
 				AuthorizeConfig: AuthorizeConfig{
 					ProxyConfig: ProxyConfig{
 						Domains: []string{"proxy.local", "root.local"},
-					},
-					EmailConfig: EmailConfig{
-						Domains: []string{"proxy.local"},
 					},
 				},
 			},

--- a/internal/auth/mux.go
+++ b/internal/auth/mux.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/buzzfeed/sso/internal/pkg/hostmux"
 	log "github.com/buzzfeed/sso/internal/pkg/logging"
-	"github.com/buzzfeed/sso/internal/pkg/options"
 
 	"github.com/datadog/datadog-go/statsd"
 )
@@ -18,13 +17,6 @@ type AuthenticatorMux struct {
 
 func NewAuthenticatorMux(config Configuration, statsdClient *statsd.Client) (*AuthenticatorMux, error) {
 	logger := log.NewLogEntry()
-
-	var validator func(string) bool
-	if len(config.AuthorizeConfig.EmailConfig.Addresses) != 0 {
-		validator = options.NewEmailAddressValidator(config.AuthorizeConfig.EmailConfig.Addresses)
-	} else {
-		validator = options.NewEmailDomainValidator(config.AuthorizeConfig.EmailConfig.Domains)
-	}
 
 	authenticators := []*Authenticator{}
 	idpMux := http.NewServeMux()
@@ -38,7 +30,6 @@ func NewAuthenticatorMux(config Configuration, statsdClient *statsd.Client) (*Au
 
 		idpSlug := idp.Data().ProviderSlug
 		authenticator, err := NewAuthenticator(config,
-			SetValidator(validator),
 			SetProvider(idp),
 			SetCookieStore(config.SessionConfig, idpSlug),
 			SetStatsdClient(statsdClient),

--- a/internal/auth/options.go
+++ b/internal/auth/options.go
@@ -95,14 +95,6 @@ func SetRedirectURL(serverConfig ServerConfig, slug string) func(*Authenticator)
 	}
 }
 
-// SetValidator sets the email validator
-func SetValidator(validator func(string) bool) func(*Authenticator) error {
-	return func(a *Authenticator) error {
-		a.Validator = validator
-		return nil
-	}
-}
-
 // SetCookieStore sets the cookie store to use a miscreant cipher
 func SetCookieStore(sessionConfig SessionConfig, providerSlug string) func(*Authenticator) error {
 	return func(a *Authenticator) error {

--- a/internal/proxy/options.go
+++ b/internal/proxy/options.go
@@ -24,8 +24,6 @@ import (
 // Cluster - the cluster in which this is running, used for upstream configs
 // Scheme - the default scheme, used for upstream configs
 // SkipAuthPreflight - will skip authentication for OPTIONS requests, default false
-// EmailDomains - csv list of emails with the specified domain to authenticate. Use * to authenticate any email
-// EmailAddresses - []string - authenticate emails with the specified email address (may be given multiple times). Use * to authenticate any email
 // DefaultAllowedGroups - csv list of default allowed groups that are applied to authorize access to upstreams. Will be overridden by groups specified in upstream configs.
 // ClientID - the OAuth Client ID: ie: "123456.apps.googleusercontent.com"
 // ClientSecret - The OAuth Client Secret
@@ -60,8 +58,6 @@ type Options struct {
 
 	SkipAuthPreflight bool `envconfig:"SKIP_AUTH_PREFLIGHT"`
 
-	EmailDomains         []string `envconfig:"EMAIL_DOMAIN"`
-	EmailAddresses       []string `envconfig:"EMAIL_ADDRESSES"`
 	DefaultAllowedGroups []string `envconfig:"DEFAULT_ALLOWED_GROUPS"`
 
 	ClientID     string `envconfig:"CLIENT_ID"`
@@ -147,10 +143,6 @@ func (o *Options) Validate() error {
 	if o.ClientSecret == "" {
 		msgs = append(msgs, "missing setting: client-secret")
 	}
-	if len(o.EmailDomains) == 0 && len(o.EmailAddresses) == 0 {
-		msgs = append(msgs, "missing setting: email-domain or email-address")
-	}
-
 	if o.StatsdHost == "" {
 		msgs = append(msgs, "missing setting: statsd-host")
 	}

--- a/internal/proxy/options_test.go
+++ b/internal/proxy/options_test.go
@@ -16,7 +16,6 @@ func testOptions() *Options {
 	o.CookieSecret = testEncodedCookieSecret
 	o.ClientID = "bazquux"
 	o.ClientSecret = "xyzzyplugh"
-	o.EmailDomains = []string{"*"}
 	o.DefaultProviderSlug = "idp"
 	o.ProviderURLString = "https://www.example.com"
 	o.UpstreamConfigsFile = "testdata/upstream_configs.yml"
@@ -41,7 +40,6 @@ func errorMsg(msgs []string) string {
 
 func TestNewOptions(t *testing.T) {
 	o := NewOptions()
-	o.EmailDomains = []string{"*"}
 	err := o.Validate()
 	testutil.NotEqual(t, nil, err)
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -25,17 +25,17 @@ func New(opts *Options) (*SSOProxy, error) {
 		optFuncs = append(optFuncs, SetRequestSigner(requestSigner))
 	}
 
-	if len(opts.EmailAddresses) != 0 {
-		optFuncs = append(optFuncs, SetValidator(options.NewEmailAddressValidator(opts.EmailAddresses)))
-	} else {
-		optFuncs = append(optFuncs, SetValidator(options.NewEmailDomainValidator(opts.EmailDomains)))
-	}
-
 	hostRouter := hostmux.NewRouter()
 	for _, upstreamConfig := range opts.upstreamConfigs {
 		provider, err := newProvider(opts, upstreamConfig)
 		if err != nil {
 			return nil, err
+		}
+
+		if len(upstreamConfig.EmailAddresses) != 0 {
+			optFuncs = append(optFuncs, SetValidator(options.NewEmailAddressValidator(upstreamConfig.EmailAddresses)))
+		} else if len(upstreamConfig.EmailDomains) != 0 {
+			optFuncs = append(optFuncs, SetValidator(options.NewEmailDomainValidator(upstreamConfig.EmailDomains)))
 		}
 
 		handler, err := NewUpstreamReverseProxy(upstreamConfig, requestSigner)

--- a/internal/proxy/proxy_config.go
+++ b/internal/proxy/proxy_config.go
@@ -92,6 +92,8 @@ type OptionsConfig struct {
 	HeaderOverrides    map[string]string `yaml:"header_overrides"`
 	SkipAuthRegex      []string          `yaml:"skip_auth_regex"`
 	AllowedGroups      []string          `yaml:"allowed_groups"`
+	EmailDomains       []string          `yaml:"allowed_email_domains"`
+	EmailAddresses     []string          `yaml:"allowed_email_addresses"`
 	TLSSkipVerify      bool              `yaml:"tls_skip_verify"`
 	PreserveHost       bool              `yaml:"preserve_host"`
 	Timeout            time.Duration     `yaml:"timeout"`
@@ -99,8 +101,6 @@ type OptionsConfig struct {
 	FlushInterval      time.Duration     `yaml:"flush_interval"`
 	SkipRequestSigning bool              `yaml:"skip_request_signing"`
 	ProviderSlug       string            `yaml:"provider_slug"`
-	EmailDomains       []string          `yaml:"email_domains"`
-	EmailAddresses     []string          `yaml:"email_addresses"`
 
 	// CookieName is still set globally, so we do not provide override behavior
 	CookieName string

--- a/internal/proxy/proxy_config.go
+++ b/internal/proxy/proxy_config.go
@@ -62,6 +62,8 @@ type UpstreamConfig struct {
 	SkipRequestSigning    bool
 	CookieName            string
 	ProviderSlug          string
+	EmailDomains          []string
+	EmailAddresses        []string
 }
 
 // RouteConfig maps to the yaml config fields,
@@ -97,6 +99,8 @@ type OptionsConfig struct {
 	FlushInterval      time.Duration     `yaml:"flush_interval"`
 	SkipRequestSigning bool              `yaml:"skip_request_signing"`
 	ProviderSlug       string            `yaml:"provider_slug"`
+	EmailDomains       []string          `yaml:"email_domains"`
+	EmailAddresses     []string          `yaml:"email_addresses"`
 
 	// CookieName is still set globally, so we do not provide override behavior
 	CookieName string
@@ -403,6 +407,8 @@ func parseOptionsConfig(proxy *UpstreamConfig, defaultOpts *OptionsConfig) error
 	proxy.SkipRequestSigning = dst.SkipRequestSigning
 	proxy.CookieName = dst.CookieName
 	proxy.ProviderSlug = dst.ProviderSlug
+	proxy.EmailDomains = dst.EmailDomains
+	proxy.EmailAddresses = dst.EmailAddresses
 
 	proxy.RouteConfig.Options = nil
 


### PR DESCRIPTION
## Problem

We currently mandate the use of a global email domain to authenticate both on the proxy side as well as the authenticator side. This is limiting for organizations and upstreams that have more diverse requirements that require a more flexible authenticator model.

We originally implemented this requirement as a safety precaution when SSO was less mature. It no longer provides the same assurances now that group usage is more robust and SSO itself has matured.

## Solution

We propose to move adjust this configuration in two ways:
1. Move the configuration in the proxy to the upstream configuration block.
2. Remove the configuration and mechanism on the proxy side. Instead, we will rely on the identity providers to provide this authentication mechanism.

## Notes

The way email domains, addresses, and groups interact with one another is becoming increasing confusing. We should think about ways to help simplify the model and make it more intuitive.
