### PR TITLE
proxy: Allow injection of request headers

### DIFF
--- a/docs/sso_config.md
+++ b/docs/sso_config.md
@@ -19,6 +19,8 @@ For example, the following config would have the following environment variables
         - ^\/github-webhook\/$
       header_overrides:
         X-Frame-Options: DENY
+      inject_request_headers:
+        Authorization: Basic dXNlcjpwYXNzd29yZA==
   prod:
     from: example-service.example.com
 ```
@@ -33,6 +35,7 @@ For example, the following config would have the following environment variables
     * **allowed groups** optional list of authorized google groups that can access the service. If not specified, anyone within an email domain is allowed to access the service. *Note*: We do not support nested group authentication at this time. Groups must be made up of email addresses associated with individual's accounts. See [#133](https://github.com/buzzfeed/sso/issues/133).
     * **skip_auth_regex** skips authentication for paths matching these regular expressions. NOTE: Use with extreme caution.
     * **header_overrides** overrides any heads set either by SSO proxy itself or upstream applications. Useful for modifying browser security headers.
+    * **inject_request_headers** adds headers to the request before the request is sent to the proxied service.  Useful for adding basic auth headers if needed.
     * **timeout** sets the amount of time that SSO Proxy will wait for the upstream to complete its request.
     * **flush_interval** sets an interval to periodically flush the buffered response to the client. If specified, SSO Proxy will not timeout requests to this upstream and will stream the response to the client. NOTE: Use with extreme caution.
   * **extra_routes** allows services to specify multiple routes. These route can includes the *from*, *to*, *type*, and *options* fields defined above and inherit any configuration

--- a/internal/proxy/oauthproxy.go
+++ b/internal/proxy/oauthproxy.go
@@ -802,6 +802,9 @@ func (p *OAuthProxy) Authenticate(rw http.ResponseWriter, req *http.Request) (er
 	req.Header.Set("X-Forwarded-Email", session.Email)
 	req.Header.Set("X-Forwarded-Groups", strings.Join(session.Groups, ","))
 
+	for key, val := range p.upstreamConfig.InjectRequestHeaders {
+		req.Header.Set(key, val)
+	}
 	// stash authenticated user so that it can be logged later (see func logRequest)
 	rw.Header().Set(loggingUserHeader, session.Email)
 

--- a/internal/proxy/oauthproxy.go
+++ b/internal/proxy/oauthproxy.go
@@ -793,6 +793,10 @@ func (p *OAuthProxy) Authenticate(rw http.ResponseWriter, req *http.Request) (er
 		return ErrUserNotAuthorized
 	}
 
+	for key, val := range p.upstreamConfig.InjectRequestHeaders {
+		req.Header.Set(key, val)
+	}
+
 	req.Header.Set("X-Forwarded-User", session.User)
 
 	if p.passAccessToken && session.AccessToken != "" {
@@ -802,9 +806,6 @@ func (p *OAuthProxy) Authenticate(rw http.ResponseWriter, req *http.Request) (er
 	req.Header.Set("X-Forwarded-Email", session.Email)
 	req.Header.Set("X-Forwarded-Groups", strings.Join(session.Groups, ","))
 
-	for key, val := range p.upstreamConfig.InjectRequestHeaders {
-		req.Header.Set(key, val)
-	}
 	// stash authenticated user so that it can be logged later (see func logRequest)
 	rw.Header().Set(loggingUserHeader, session.Email)
 

--- a/internal/proxy/proxy_config.go
+++ b/internal/proxy/proxy_config.go
@@ -59,6 +59,7 @@ type UpstreamConfig struct {
 	ResetDeadline         time.Duration
 	FlushInterval         time.Duration
 	HeaderOverrides       map[string]string
+	InjectRequestHeaders  map[string]string
 	SkipRequestSigning    bool
 	CookieName            string
 	ProviderSlug          string
@@ -87,16 +88,17 @@ type RouteConfig struct {
 // * skip_request_signing - skip request signing if this behavior is problematic or undesired. For requests with large http bodies
 //   this maybe useful to unset as http bodies are read into memory in order to sign.
 type OptionsConfig struct {
-	HeaderOverrides    map[string]string `yaml:"header_overrides"`
-	SkipAuthRegex      []string          `yaml:"skip_auth_regex"`
-	AllowedGroups      []string          `yaml:"allowed_groups"`
-	TLSSkipVerify      bool              `yaml:"tls_skip_verify"`
-	PreserveHost       bool              `yaml:"preserve_host"`
-	Timeout            time.Duration     `yaml:"timeout"`
-	ResetDeadline      time.Duration     `yaml:"reset_deadline"`
-	FlushInterval      time.Duration     `yaml:"flush_interval"`
-	SkipRequestSigning bool              `yaml:"skip_request_signing"`
-	ProviderSlug       string            `yaml:"provider_slug"`
+	HeaderOverrides      map[string]string `yaml:"header_overrides"`
+	InjectRequestHeaders map[string]string `yaml:"inject_request_headers"`
+	SkipAuthRegex        []string          `yaml:"skip_auth_regex"`
+	AllowedGroups        []string          `yaml:"allowed_groups"`
+	TLSSkipVerify        bool              `yaml:"tls_skip_verify"`
+	PreserveHost         bool              `yaml:"preserve_host"`
+	Timeout              time.Duration     `yaml:"timeout"`
+	ResetDeadline        time.Duration     `yaml:"reset_deadline"`
+	FlushInterval        time.Duration     `yaml:"flush_interval"`
+	SkipRequestSigning   bool              `yaml:"skip_request_signing"`
+	ProviderSlug         string            `yaml:"provider_slug"`
 
 	// CookieName is still set globally, so we do not provide override behavior
 	CookieName string
@@ -398,6 +400,7 @@ func parseOptionsConfig(proxy *UpstreamConfig, defaultOpts *OptionsConfig) error
 	proxy.ResetDeadline = dst.ResetDeadline
 	proxy.FlushInterval = dst.FlushInterval
 	proxy.HeaderOverrides = dst.HeaderOverrides
+	proxy.InjectRequestHeaders = dst.InjectRequestHeaders
 	proxy.TLSSkipVerify = dst.TLSSkipVerify
 	proxy.PreserveHost = dst.PreserveHost
 	proxy.SkipRequestSigning = dst.SkipRequestSigning


### PR DESCRIPTION
* Added InjectRequestHeaders to UpstreamConfig/OptionsConfig
* Loop over InjectRequestHeaders during Authenticate and add headers to the request

## Problem
#243 

## Notes

I am unfamiliar with Go and was unsure how to go about testing the actual adding of the headers.  If someone would be kind enough to point me in the right direction I can continue.
