### PR TITLE
sso-proxy: add websocket support

### DIFF
--- a/internal/proxy/logging_handler.go
+++ b/internal/proxy/logging_handler.go
@@ -4,7 +4,10 @@
 package proxy
 
 import (
+	"bufio"
+	"errors"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -36,6 +39,14 @@ func (l *responseLogger) extractUser() {
 		l.authInfo = authInfo
 		l.w.Header().Del(loggingUserHeader)
 	}
+}
+
+// Support Websockets
+func (l *responseLogger) Hijack() (rwc net.Conn, buf *bufio.ReadWriter, err error) {
+	if hij, ok := l.w.(http.Hijacker); ok {
+		return hij.Hijack()
+	}
+	return nil, nil, errors.New("http.Hijacker is not available on writer")
 }
 
 func (l *responseLogger) Write(b []byte) (int, error) {


### PR DESCRIPTION
## Problem
Add support for WebSockets 

## Solution
What is the proposed solution?
Since we started building on go1.12 with native WebSocket proxy support, the only thing needed is to implement `Hijacker` on `responseLogger` to support WebSockets.
Fixes #103

## Notes
To proxy WebSocket successfully, an appropriate flush_interval is required. 
This pr is tested to proxy [weave-scope](github.com/weaveworks/scope) with a flush_interval of 0.1s