### PR TITLE
sso_auth: add default for groupcache settings

### DIFF
--- a/internal/auth/configuration.go
+++ b/internal/auth/configuration.go
@@ -66,6 +66,12 @@ import (
 func DefaultAuthConfig() Configuration {
 	return Configuration{
 		ProviderConfigs: map[string]ProviderConfig{},
+		GroupCacheConfig: GroupCacheConfig{
+			CacheIntervalConfig: CacheIntervalConfig{
+				Provider: 10 * time.Minute,
+				Refresh:  10 * time.Minute,
+			},
+		},
 		ClientConfigs: map[string]ClientConfig{
 			"proxy": ClientConfig{},
 		},
@@ -134,13 +140,14 @@ var (
 
 // Configuration is the parent struct that holds all the configuration
 type Configuration struct {
-	ProviderConfigs map[string]ProviderConfig `mapstructure:"provider"`
-	ClientConfigs   map[string]ClientConfig   `mapstructure:"client"`
-	AuthorizeConfig AuthorizeConfig           `mapstructure:"authorize"`
-	SessionConfig   SessionConfig             `mapstructure:"session"`
-	ServerConfig    ServerConfig              `mapstructure:"server"`
-	MetricsConfig   MetricsConfig             `mapstructrue:"metrics"`
-	LoggingConfig   LoggingConfig             `mapstructure:"logging"`
+	ProviderConfigs  map[string]ProviderConfig `mapstructure:"provider"`
+	ClientConfigs    map[string]ClientConfig   `mapstructure:"client"`
+	GroupCacheConfig GroupCacheConfig          `mapstructure:"groupcache"`
+	AuthorizeConfig  AuthorizeConfig           `mapstructure:"authorize"`
+	SessionConfig    SessionConfig             `mapstructure:"session"`
+	ServerConfig     ServerConfig              `mapstructure:"server"`
+	MetricsConfig    MetricsConfig             `mapstructrue:"metrics"`
+	LoggingConfig    LoggingConfig             `mapstructure:"logging"`
 }
 
 func (c Configuration) Validate() error {
@@ -268,10 +275,12 @@ func (opc OktaProviderConfig) Validate() error {
 }
 
 type GroupCacheConfig struct {
-	Interval struct {
-		Provider time.Duration `mapstructure:"provider"`
-		Refresh  time.Duration `mapstructure:"refresh"`
-	} `mapstructure:"interval"`
+	CacheIntervalConfig CacheIntervalConfig `mapstructure:"interval"`
+}
+
+type CacheIntervalConfig struct {
+	Provider time.Duration `mapstructure:"provider"`
+	Refresh  time.Duration `mapstructure:"refresh"`
 }
 
 func (gcc GroupCacheConfig) Validate() error {

--- a/internal/auth/options.go
+++ b/internal/auth/options.go
@@ -37,7 +37,7 @@ func newProvider(pc ProviderConfig, sc SessionConfig) (providers.Provider, error
 			return nil, err
 		}
 
-		cache := groups.NewFillCache(googleProvider.PopulateMembers, pc.GroupCacheConfig.Interval.Refresh)
+		cache := groups.NewFillCache(googleProvider.PopulateMembers, pc.GroupCacheConfig.CacheIntervalConfig.Refresh)
 		googleProvider.GroupsCache = cache
 
 		singleFlightProvider = providers.NewSingleFlightProvider(googleProvider)
@@ -49,7 +49,7 @@ func newProvider(pc ProviderConfig, sc SessionConfig) (providers.Provider, error
 		}
 
 		tags := []string{"provider:okta"}
-		cache := providers.NewGroupCache(oktaProvider, pc.GroupCacheConfig.Interval.Provider, oktaProvider.StatsdClient, tags)
+		cache := providers.NewGroupCache(oktaProvider, pc.GroupCacheConfig.CacheIntervalConfig.Provider, oktaProvider.StatsdClient, tags)
 		singleFlightProvider = providers.NewSingleFlightProvider(cache)
 	case "test":
 		return providers.NewTestProvider(nil), nil


### PR DESCRIPTION
## Problem 

If `c.refreshTTL` is not greater than 0 then a panic is caused upon the execution of https://github.com/buzzfeed/sso/blob/9c169b34603a63883f26dc2b717e65df34b0503f/internal/pkg/groups/fillcache.go#L118

At the moment, there's no default for this so it must be explicitly set to avoid a panic.

## Solution

Set a sane default for `refreshTTL` (this default was removed during the overhaul of configuration options).