### PR TITLE
sso_proxy: ability to define allowed email address/domain in upstream config

### DIFF
--- a/cmd/sso-proxy/main.go
+++ b/cmd/sso-proxy/main.go
@@ -29,7 +29,7 @@ func main() {
 
 	err = opts.Validate()
 	if err != nil {
-		logger.Error(err, "error validing options")
+		logger.Error(err, "error validating options")
 		os.Exit(1)
 	}
 

--- a/docs/sso_config.md
+++ b/docs/sso_config.md
@@ -33,6 +33,8 @@ For example, the following config would have the following environment variables
   * **type** declares the type of route to use, right now there is just *simple* and *rewrite*.
   * **options** are a set of options that can be added to your configuration.
     * **allowed groups** optional list of authorized google groups that can access the service. If not specified, anyone within an email domain is allowed to access the service. *Note*: We do not support nested group authentication at this time. Groups must be made up of email addresses associated with individual's accounts. See [#133](https://github.com/buzzfeed/sso/issues/133).
+    * **allowed_email_domains** optional list of authorized email domains that can access the service.
+    * **allowed_email_addresses** optional list of authorized email addresses that can access the service.
     * **skip_auth_regex** skips authentication for paths matching these regular expressions. NOTE: Use with extreme caution.
     * **header_overrides** overrides any heads set either by SSO proxy itself or upstream applications. Useful for modifying browser security headers.
     * **inject_request_headers** adds headers to the request before the request is sent to the proxied service.  Useful for adding basic auth headers if needed.

--- a/internal/pkg/options/email_address_validator.go
+++ b/internal/pkg/options/email_address_validator.go
@@ -9,11 +9,14 @@ import (
 // of email addresses. The address "*" is a wild card that matches any non-empty email.
 func NewEmailAddressValidator(emails []string) func(string) bool {
 	allowAll := false
-	for i, email := range emails {
+	var emailAddresses []string
+
+	for _, email := range emails {
 		if email == "*" {
 			allowAll = true
 		}
-		emails[i] = fmt.Sprintf("%s", strings.ToLower(email))
+		emailAddress := fmt.Sprintf("%s", strings.ToLower(email))
+		emailAddresses = append(emailAddresses, emailAddress)
 	}
 
 	if allowAll {
@@ -25,7 +28,7 @@ func NewEmailAddressValidator(emails []string) func(string) bool {
 			return false
 		}
 		email = strings.ToLower(email)
-		for _, emailItem := range emails {
+		for _, emailItem := range emailAddresses {
 			if email == emailItem {
 				return true
 			}

--- a/internal/pkg/options/email_domain_validator.go
+++ b/internal/pkg/options/email_domain_validator.go
@@ -9,11 +9,14 @@ import (
 // of domains. The domain "*" is a wild card that matches any non-empty email.
 func NewEmailDomainValidator(domains []string) func(string) bool {
 	allowAll := false
-	for i, domain := range domains {
+	var emailDomains []string
+
+	for _, domain := range domains {
 		if domain == "*" {
 			allowAll = true
 		}
-		domains[i] = fmt.Sprintf("@%s", strings.ToLower(domain))
+		emailDomain := fmt.Sprintf("@%s", strings.ToLower(domain))
+		emailDomains = append(emailDomains, emailDomain)
 	}
 
 	if allowAll {
@@ -25,7 +28,7 @@ func NewEmailDomainValidator(domains []string) func(string) bool {
 			return false
 		}
 		email = strings.ToLower(email)
-		for _, domain := range domains {
+		for _, domain := range emailDomains {
 			if strings.HasSuffix(email, domain) {
 				return true
 			}

--- a/internal/proxy/options_test.go
+++ b/internal/proxy/options_test.go
@@ -16,7 +16,7 @@ func testOptions() *Options {
 	o.CookieSecret = testEncodedCookieSecret
 	o.ClientID = "bazquux"
 	o.ClientSecret = "xyzzyplugh"
-	o.EmailDomains = []string{"*"}
+	o.DefaultAllowedEmailDomains = []string{"*"}
 	o.DefaultProviderSlug = "idp"
 	o.ProviderURLString = "https://www.example.com"
 	o.UpstreamConfigsFile = "testdata/upstream_configs.yml"
@@ -41,7 +41,12 @@ func errorMsg(msgs []string) string {
 
 func TestNewOptions(t *testing.T) {
 	o := NewOptions()
-	o.EmailDomains = []string{"*"}
+
+	upstreamConfig := &UpstreamConfig{
+		Service: "testService",
+	}
+	o.upstreamConfigs = []*UpstreamConfig{upstreamConfig}
+
 	err := o.Validate()
 	testutil.NotEqual(t, nil, err)
 
@@ -54,6 +59,7 @@ func TestNewOptions(t *testing.T) {
 		"missing setting: client-secret",
 		"missing setting: statsd-host",
 		"missing setting: statsd-port",
+		"missing setting: DEFAULT_ALLOWED_EMAIL_DOMAINS or DEFAULT_ALLOWED_EMAIL_ADDRESSES in either environment or upstream config in the following upstreams: [testService]",
 		"Invalid value for COOKIE_SECRET; must decode to 32 or 64 bytes, but decoded to 0 bytes",
 	})
 	testutil.Equal(t, expected, err.Error())

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -25,12 +25,6 @@ func New(opts *Options) (*SSOProxy, error) {
 		optFuncs = append(optFuncs, SetRequestSigner(requestSigner))
 	}
 
-	if len(opts.EmailAddresses) != 0 {
-		optFuncs = append(optFuncs, SetValidator(options.NewEmailAddressValidator(opts.EmailAddresses)))
-	} else {
-		optFuncs = append(optFuncs, SetValidator(options.NewEmailDomainValidator(opts.EmailDomains)))
-	}
-
 	hostRouter := hostmux.NewRouter()
 	for _, upstreamConfig := range opts.upstreamConfigs {
 		provider, err := newProvider(opts, upstreamConfig)
@@ -41,6 +35,12 @@ func New(opts *Options) (*SSOProxy, error) {
 		handler, err := NewUpstreamReverseProxy(upstreamConfig, requestSigner)
 		if err != nil {
 			return nil, err
+		}
+
+		if len(upstreamConfig.AllowedEmailAddresses) != 0 {
+			optFuncs = append(optFuncs, SetValidator(options.NewEmailAddressValidator(upstreamConfig.AllowedEmailAddresses)))
+		} else if len(upstreamConfig.AllowedEmailDomains) != 0 {
+			optFuncs = append(optFuncs, SetValidator(options.NewEmailDomainValidator(upstreamConfig.AllowedEmailDomains)))
 		}
 
 		optFuncs = append(optFuncs,

--- a/internal/proxy/proxy_config.go
+++ b/internal/proxy/proxy_config.go
@@ -52,6 +52,8 @@ type UpstreamConfig struct {
 
 	SkipAuthCompiledRegex []*regexp.Regexp
 	AllowedGroups         []string
+	AllowedEmailDomains   []string
+	AllowedEmailAddresses []string
 	TLSSkipVerify         bool
 	PreserveHost          bool
 	HMACAuth              hmacauth.HmacAuth
@@ -88,17 +90,19 @@ type RouteConfig struct {
 // * skip_request_signing - skip request signing if this behavior is problematic or undesired. For requests with large http bodies
 //   this maybe useful to unset as http bodies are read into memory in order to sign.
 type OptionsConfig struct {
-	HeaderOverrides      map[string]string `yaml:"header_overrides"`
-	InjectRequestHeaders map[string]string `yaml:"inject_request_headers"`
-	SkipAuthRegex        []string          `yaml:"skip_auth_regex"`
-	AllowedGroups        []string          `yaml:"allowed_groups"`
-	TLSSkipVerify        bool              `yaml:"tls_skip_verify"`
-	PreserveHost         bool              `yaml:"preserve_host"`
-	Timeout              time.Duration     `yaml:"timeout"`
-	ResetDeadline        time.Duration     `yaml:"reset_deadline"`
-	FlushInterval        time.Duration     `yaml:"flush_interval"`
-	SkipRequestSigning   bool              `yaml:"skip_request_signing"`
-	ProviderSlug         string            `yaml:"provider_slug"`
+	HeaderOverrides       map[string]string `yaml:"header_overrides"`
+	InjectRequestHeaders  map[string]string `yaml:"inject_request_headers"`
+	SkipAuthRegex         []string          `yaml:"skip_auth_regex"`
+	AllowedGroups         []string          `yaml:"allowed_groups"`
+	AllowedEmailDomains   []string          `yaml:"allowed_email_domains"`
+	AllowedEmailAddresses []string          `yaml:"allowed_email_addresses"`
+	TLSSkipVerify         bool              `yaml:"tls_skip_verify"`
+	PreserveHost          bool              `yaml:"preserve_host"`
+	Timeout               time.Duration     `yaml:"timeout"`
+	ResetDeadline         time.Duration     `yaml:"reset_deadline"`
+	FlushInterval         time.Duration     `yaml:"flush_interval"`
+	SkipRequestSigning    bool              `yaml:"skip_request_signing"`
+	ProviderSlug          string            `yaml:"provider_slug"`
 
 	// CookieName is still set globally, so we do not provide override behavior
 	CookieName string
@@ -396,6 +400,8 @@ func parseOptionsConfig(proxy *UpstreamConfig, defaultOpts *OptionsConfig) error
 	}
 
 	proxy.AllowedGroups = dst.AllowedGroups
+	proxy.AllowedEmailDomains = dst.AllowedEmailDomains
+	proxy.AllowedEmailAddresses = dst.AllowedEmailAddresses
 	proxy.Timeout = dst.Timeout
 	proxy.ResetDeadline = dst.ResetDeadline
 	proxy.FlushInterval = dst.FlushInterval

--- a/quickstart/docker-compose.yml
+++ b/quickstart/docker-compose.yml
@@ -25,11 +25,11 @@ services:
     entrypoint: /bin/sso-proxy
     environment:
       # Allow any google account to log in for demo purposes
-      - EMAIL_DOMAIN=*
+      - DEFAULT_ALLOWED_EMAIL_DOMAINS=*
 
       # (Optional) Allow specific google email address to log in for demo purposes
-      # This overrides EMAIL_DOMAIN
-      # - EMAIL_ADDRESSES=*
+      # This overrides DEFAULT_ALLOWED_EMAIL_DOMAIN
+      # - DEFAULT_ALLOWED_EMAIL_ADDRESSES=*
 
       - UPSTREAM_CONFIGS=/sso/upstream_configs.yml
       - PROVIDER_URL=http://sso-auth.localtest.me

--- a/quickstart/kubernetes/sso-proxy-deployment.yml
+++ b/quickstart/kubernetes/sso-proxy-deployment.yml
@@ -19,7 +19,7 @@ spec:
         ports:
         - containerPort: 4180
         env:
-          - name: EMAIL_DOMAIN
+          - name: DEFAULT_ALLOWED_EMAIL_DOMAINS
             value: 'mydomain.com'
           - name: UPSTREAM_CONFIGS
             value: /sso/upstream_configs.yml


### PR DESCRIPTION
## Problem
Allowed email addresses and domains can only be specified for SSO as a whole, setting the same restriction on all upstreams. It cannot be set on individual upstreams.

## Solution

Allow these variables to be defined in two separate places:
- in the environment (in the standard 'options' config), acting as a default setting for all upstreams
- within individual upstream configs, overriding the 'default' setting

We still expect one of these to be set and will error if neither are.

## Notes

Includes small bug fix to both the email address validator and email domain validator packages to avoid mutating the passed in slice, instead opting to create and append to a new one. 