### PR TITLE
sso_*: allow simultaneous use of Validators

### DIFF
--- a/internal/auth/mux.go
+++ b/internal/auth/mux.go
@@ -18,12 +18,11 @@ type AuthenticatorMux struct {
 
 func NewAuthenticatorMux(config Configuration, statsdClient *statsd.Client) (*AuthenticatorMux, error) {
 	logger := log.NewLogEntry()
-
-	var validator func(string) bool
+	validators := []options.Validator{}
 	if len(config.AuthorizeConfig.EmailConfig.Addresses) != 0 {
-		validator = options.NewEmailAddressValidator(config.AuthorizeConfig.EmailConfig.Addresses)
+		validators = append(validators, options.NewEmailAddressValidator(config.AuthorizeConfig.EmailConfig.Addresses))
 	} else {
-		validator = options.NewEmailDomainValidator(config.AuthorizeConfig.EmailConfig.Domains)
+		validators = append(validators, options.NewEmailDomainValidator(config.AuthorizeConfig.EmailConfig.Domains))
 	}
 
 	authenticators := []*Authenticator{}
@@ -38,7 +37,7 @@ func NewAuthenticatorMux(config Configuration, statsdClient *statsd.Client) (*Au
 
 		idpSlug := idp.Data().ProviderSlug
 		authenticator, err := NewAuthenticator(config,
-			SetValidator(validator),
+			SetValidators(validators),
 			SetProvider(idp),
 			SetCookieStore(config.SessionConfig, idpSlug),
 			SetStatsdClient(statsdClient),

--- a/internal/auth/options.go
+++ b/internal/auth/options.go
@@ -9,6 +9,7 @@ import (
 	"github.com/buzzfeed/sso/internal/auth/providers"
 	"github.com/buzzfeed/sso/internal/pkg/aead"
 	"github.com/buzzfeed/sso/internal/pkg/groups"
+	"github.com/buzzfeed/sso/internal/pkg/options"
 	"github.com/buzzfeed/sso/internal/pkg/sessions"
 
 	"github.com/datadog/datadog-go/statsd"
@@ -96,9 +97,9 @@ func SetRedirectURL(serverConfig ServerConfig, slug string) func(*Authenticator)
 }
 
 // SetValidator sets the email validator
-func SetValidator(validator func(string) bool) func(*Authenticator) error {
+func SetValidators(validators []options.Validator) func(*Authenticator) error {
 	return func(a *Authenticator) error {
-		a.Validator = validator
+		a.Validators = validators
 		return nil
 	}
 }

--- a/internal/pkg/options/email_domain_validator.go
+++ b/internal/pkg/options/email_domain_validator.go
@@ -1,38 +1,75 @@
 package options
 
 import (
+	"errors"
 	"fmt"
 	"strings"
+
+	"github.com/buzzfeed/sso/internal/pkg/sessions"
 )
 
-// NewEmailDomainValidator returns a function that checks whether a given email is valid based on a list
-// of domains. The domain "*" is a wild card that matches any non-empty email.
-func NewEmailDomainValidator(domains []string) func(string) bool {
-	allowAll := false
-	var emailDomains []string
+var (
+	_ Validator = &EmailDomainValidator{}
 
-	for _, domain := range domains {
+	// These error message should be formatted in such a way that is appropriate
+	// for display to the end user.
+	ErrEmailDomainDenied = errors.New("Unauthorized Email Domain")
+)
+
+type EmailDomainValidator struct {
+	AllowedDomains []string
+}
+
+// NewEmailDomainValidator takes in a list of domains and returns a Validator object.
+// The validator can be used to validate that the session.Email:
+// - is non-empty
+// - the domain of the email address matches one of the originally passed in domains.
+//   (case insensitive)
+// - if the originally passed in list of domains consists only of "*", then all emails
+//   are considered valid based on their domain.
+// If valid, nil is returned in place of an error.
+func NewEmailDomainValidator(allowedDomains []string) *EmailDomainValidator {
+	emailDomains := make([]string, 0, len(allowedDomains))
+
+	for _, domain := range allowedDomains {
 		if domain == "*" {
-			allowAll = true
+			emailDomains = append(emailDomains, domain)
+		} else {
+			emailDomain := fmt.Sprintf("@%s", strings.ToLower(domain))
+			emailDomains = append(emailDomains, emailDomain)
 		}
-		emailDomain := fmt.Sprintf("@%s", strings.ToLower(domain))
-		emailDomains = append(emailDomains, emailDomain)
+	}
+	return &EmailDomainValidator{
+		AllowedDomains: emailDomains,
+	}
+}
+
+func (v *EmailDomainValidator) Validate(session *sessions.SessionState) error {
+	if session.Email == "" {
+		return ErrInvalidEmailAddress
 	}
 
-	if allowAll {
-		return func(email string) bool { return email != "" }
+	if len(v.AllowedDomains) == 0 {
+		return ErrEmailDomainDenied
 	}
 
-	return func(email string) bool {
-		if email == "" {
-			return false
-		}
-		email = strings.ToLower(email)
-		for _, domain := range emailDomains {
-			if strings.HasSuffix(email, domain) {
-				return true
-			}
-		}
-		return false
+	if len(v.AllowedDomains) == 1 && v.AllowedDomains[0] == "*" {
+		return nil
 	}
+
+	err := v.validate(session)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (v *EmailDomainValidator) validate(session *sessions.SessionState) error {
+	email := strings.ToLower(session.Email)
+	for _, domain := range v.AllowedDomains {
+		if strings.HasSuffix(email, domain) {
+			return nil
+		}
+	}
+	return ErrEmailDomainDenied
 }

--- a/internal/pkg/options/email_domain_validator_test.go
+++ b/internal/pkg/options/email_domain_validator_test.go
@@ -2,119 +2,147 @@ package options
 
 import (
 	"testing"
+
+	"github.com/buzzfeed/sso/internal/pkg/sessions"
 )
 
 func TestEmailDomainValidatorValidator(t *testing.T) {
 	testCases := []struct {
-		name        string
-		domains     []string
-		email       string
-		expectValid bool
+		name           string
+		allowedDomains []string
+		email          string
+		expectedErr    error
+		session        *sessions.SessionState
 	}{
 		{
-			name:        "nothing should validate when domain list is empty",
-			domains:     []string(nil),
-			email:       "foo@example.com",
-			expectValid: false,
+			name:           "nothing should validate when domain list is empty",
+			allowedDomains: []string(nil),
+			session: &sessions.SessionState{
+				Email: "foo@example.com",
+			},
+			expectedErr: ErrEmailDomainDenied,
 		},
 		{
-			name:        "single domain validation",
-			domains:     []string{"example.com"},
-			email:       "foo@example.com",
-			expectValid: true,
+			name:           "single domain validation",
+			allowedDomains: []string{"example.com"},
+			session: &sessions.SessionState{
+				Email: "foo@example.com",
+			},
+			expectedErr: nil,
 		},
 		{
-			name:        "substring matches are rejected",
-			domains:     []string{"example.com"},
-			email:       "foo@hackerexample.com",
-			expectValid: false,
+			name:           "substring matches are rejected",
+			allowedDomains: []string{"example.com"},
+			session: &sessions.SessionState{
+				Email: "foo@hackerexample.com",
+			},
+			expectedErr: ErrEmailDomainDenied,
 		},
 		{
-			name:        "no subdomain rollup happens",
-			domains:     []string{"example.com"},
-			email:       "foo@bar.example.com",
-			expectValid: false,
+			name:           "no subdomain rollup happens",
+			allowedDomains: []string{"example.com"},
+			session: &sessions.SessionState{
+				Email: "foo@bar.example.com",
+			},
+			expectedErr: ErrEmailDomainDenied,
 		},
 		{
-			name:        "multiple domain validation still rejects other domains",
-			domains:     []string{"abc.com", "xyz.com"},
-			email:       "foo@example.com",
-			expectValid: false,
+			name:           "multiple domain validation still rejects other domains",
+			allowedDomains: []string{"abc.com", "xyz.com"},
+			session: &sessions.SessionState{
+				Email: "foo@example.com",
+			},
+			expectedErr: ErrEmailDomainDenied,
 		},
 		{
-			name:        "multiple domain validation still accepts emails from either domain",
-			domains:     []string{"abc.com", "xyz.com"},
-			email:       "foo@abc.com",
-			expectValid: true,
+			name:           "multiple domain validation still accepts emails from either domain",
+			allowedDomains: []string{"abc.com", "xyz.com"},
+			session: &sessions.SessionState{
+				Email: "foo@abc.com",
+			},
+			expectedErr: nil,
 		},
 		{
-			name:        "multiple domain validation still rejects other domains",
-			domains:     []string{"abc.com", "xyz.com"},
-			email:       "bar@xyz.com",
-			expectValid: true,
+			name:           "multiple domain validation still rejects other domains",
+			allowedDomains: []string{"abc.com", "xyz.com"},
+			session: &sessions.SessionState{
+				Email: "bar@xyz.com",
+			},
+			expectedErr: nil,
 		},
 		{
-			name:        "comparisons are case insensitive",
-			domains:     []string{"Example.Com"},
-			email:       "foo@example.com",
-			expectValid: true,
+			name:           "comparisons are case insensitive",
+			allowedDomains: []string{"Example.Com"},
+			session: &sessions.SessionState{
+				Email: "foo@example.com",
+			},
+			expectedErr: nil,
 		},
 		{
-			name:        "comparisons are case insensitive",
-			domains:     []string{"Example.Com"},
-			email:       "foo@EXAMPLE.COM",
-			expectValid: true,
+			name:           "comparisons are case insensitive",
+			allowedDomains: []string{"Example.Com"},
+			session: &sessions.SessionState{
+				Email: "foo@EXAMPLE.COM",
+			},
+			expectedErr: nil,
 		},
 		{
-			name:        "comparisons are case insensitive",
-			domains:     []string{"example.com"},
-			email:       "foo@ExAmPlE.CoM",
-			expectValid: true,
+			name:           "comparisons are case insensitive",
+			allowedDomains: []string{"example.com"},
+			session: &sessions.SessionState{
+				Email: "foo@ExAmPLE.CoM",
+			},
+			expectedErr: nil,
 		},
 		{
-			name:        "single wildcard allows all",
-			domains:     []string{"*"},
-			email:       "foo@example.com",
-			expectValid: true,
+			name:           "single wildcard allows all",
+			allowedDomains: []string{"*"},
+			session: &sessions.SessionState{
+				Email: "foo@example.com",
+			},
+			expectedErr: nil,
 		},
 		{
-			name:        "single wildcard allows all",
-			domains:     []string{"*"},
-			email:       "bar@gmail.com",
-			expectValid: true,
+			name:           "single wildcard allows all",
+			allowedDomains: []string{"*"},
+			session: &sessions.SessionState{
+				Email: "bar@gmail.com",
+			},
+			expectedErr: nil,
 		},
 		{
-			name:        "wildcard in list allows all",
-			domains:     []string{"example.com", "*"},
-			email:       "foo@example.com",
-			expectValid: true,
+			name:           "wildcard is ignored if other domains are included",
+			allowedDomains: []string{"*", "example.com"},
+			session: &sessions.SessionState{
+				Email: "foo@gmal.com",
+			},
+			expectedErr: ErrEmailDomainDenied,
 		},
 		{
-			name:        "wildcard in list allows all",
-			domains:     []string{"example.com", "*"},
-			email:       "foo@gmail.com",
-			expectValid: true,
+			name:           "empty email rejected",
+			allowedDomains: []string{"example.com"},
+			email:          "",
+			session: &sessions.SessionState{
+				Email: "foo@example.com",
+			},
+			expectedErr: nil,
 		},
 		{
-			name:        "empty email rejected",
-			domains:     []string{"example.com"},
-			email:       "",
-			expectValid: false,
-		},
-		{
-			name:        "wildcard still rejects empty emails",
-			domains:     []string{"*"},
-			email:       "",
-			expectValid: false,
+			name:           "wildcard still rejects empty emails",
+			allowedDomains: []string{"*"},
+			session: &sessions.SessionState{
+				Email: "",
+			},
+			expectedErr: ErrInvalidEmailAddress,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			emailValidator := NewEmailDomainValidator(tc.domains)
-			valid := emailValidator(tc.email)
-			if valid != tc.expectValid {
-				t.Fatalf("expected %v, got %v", tc.expectValid, valid)
+			emailValidator := NewEmailDomainValidator(tc.allowedDomains)
+			err := emailValidator.Validate(tc.session)
+			if err != tc.expectedErr {
+				t.Fatalf("expected %v, got %v", tc.expectedErr, err)
 			}
 		})
 	}

--- a/internal/pkg/options/email_group_validator.go
+++ b/internal/pkg/options/email_group_validator.go
@@ -1,0 +1,60 @@
+package options
+
+import (
+	"errors"
+
+	"github.com/buzzfeed/sso/internal/pkg/sessions"
+	"github.com/buzzfeed/sso/internal/proxy/providers"
+)
+
+var (
+	_ Validator = EmailGroupValidator{}
+
+	// These error message should be formatted in such a way that is appropriate
+	// for display to the end user.
+	ErrGroupMembership = errors.New("Invalid Group Membership")
+)
+
+type EmailGroupValidator struct {
+	Provider      providers.Provider
+	AllowedGroups []string
+}
+
+// NewEmailGroupValidator takes in a Provider object and a list of groups, and returns a Validator object.
+// The validator can be used to validate that the session.Email:
+// - if an empty list is passed in in place of a list of groups, all session.Emails will be considered valid
+//   regardless of group membership with that particular Provider.
+// - according to the Provider that was passed in, is a member of one of the originally passed in groups.
+// If valid, nil is returned in place of an error.
+func NewEmailGroupValidator(provider providers.Provider, allowedGroups []string) EmailGroupValidator {
+	return EmailGroupValidator{
+		Provider:      provider,
+		AllowedGroups: allowedGroups,
+	}
+}
+
+func (v EmailGroupValidator) Validate(session *sessions.SessionState) error {
+	if len(v.AllowedGroups) == 0 {
+		return nil
+	}
+
+	err := v.validate(session)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (v EmailGroupValidator) validate(session *sessions.SessionState) error {
+	matchedGroups, valid, err := v.Provider.ValidateGroup(session.Email, v.AllowedGroups, session.AccessToken)
+	if err != nil {
+		return ErrValidationError
+	}
+
+	if valid {
+		session.Groups = matchedGroups
+		return nil
+	}
+
+	return ErrGroupMembership
+}

--- a/internal/pkg/options/mock_validator.go
+++ b/internal/pkg/options/mock_validator.go
@@ -1,0 +1,29 @@
+package options
+
+import (
+	"errors"
+
+	"github.com/buzzfeed/sso/internal/pkg/sessions"
+)
+
+var (
+	_ Validator = EmailAddressValidator{}
+)
+
+type MockValidator struct {
+	Result bool
+}
+
+func NewMockValidator(result bool) MockValidator {
+	return MockValidator{
+		Result: result,
+	}
+}
+
+func (v MockValidator) Validate(session *sessions.SessionState) error {
+	if v.Result {
+		return nil
+	}
+
+	return errors.New("MockValidator error")
+}

--- a/internal/pkg/options/validators.go
+++ b/internal/pkg/options/validators.go
@@ -1,0 +1,32 @@
+package options
+
+import (
+	"errors"
+
+	"github.com/buzzfeed/sso/internal/pkg/sessions"
+)
+
+var (
+	// These error message should be formatted in such a way that is appropriate
+	// for display to the end user.
+	ErrInvalidEmailAddress = errors.New("Invalid Email Address In Session State")
+	ErrValidationError     = errors.New("Error during validation")
+)
+
+type Validator interface {
+	Validate(*sessions.SessionState) error
+}
+
+// RunValidators runs each passed in validator and returns a slice of errors. If an
+// empty slice is returned, it can be assumed all passed in validators were successful.
+func RunValidators(validators []Validator, session *sessions.SessionState) []error {
+	validatorErrors := make([]error, 0, len(validators))
+
+	for _, validator := range validators {
+		err := validator.Validate(session)
+		if err != nil {
+			validatorErrors = append(validatorErrors, err)
+		}
+	}
+	return validatorErrors
+}


### PR DESCRIPTION
## Problem

The connection between `AllowedEmailDomains`, `AllowedEmailAddresses`, and `AllowedGroups` is unclear. If all specified, they don't work together well which causes awkward workarounds to be put into place.

## Solution

Introduce a more structured 'Validator' type within SSO, allowing us to create better and clearer dynamics between these settings (and any other validators that may be added in the future).

There are currently three separate validators: 
- Email Domain
- Email Address
- Email Group

**SSO will now allow the request through providing at least _one_ of these validators pass.**


## Notes

- I would suggest looking at the following files together: 
```
- internal/pkg/options/validators.go
- internal/pkg/options/email_address_validator.go
- internal/pkg/options/email_domain_validator.go
- internal/pkg/options/email_group_validator.go
```
```
- internal/proxy/proxy.go
- internal/proxy/oauthproxy.go
```
```
- internal/auth/authenticator.go
- internal/auth/mux.go
- internal/auth/options.go
```
```
- internal/pkg/options/mock_validator.go
- internal/auth/authenticator_test.go
- internal/proxy/oauthproxy_test.go
```
```
- internal/pkg/options/email_address_validator_test.go
- internal/pkg/options/email_domain_validator_test.go
```


- This also changes the use of the `*` wildcard within `AllowedEmailDomains` and `AllowedEmailAddresses`. **The wildcard will be ignored if other domains/email addresses are also passed with it, choosing to follow the most restrictive path.**


- On second thoughts..I think it may have been clearer to recreate the validator files from scratch!