### PR TITLE
sso_*: fix 500 error caused by expired Okta refresh token

### DIFF
--- a/internal/auth/authenticator.go
+++ b/internal/auth/authenticator.go
@@ -259,6 +259,9 @@ func (p *Authenticator) SignIn(rw http.ResponseWriter, req *http.Request) {
 		p.ProxyOAuthRedirect(rw, req, session, tags)
 	case http.ErrNoCookie:
 		p.SignInPage(rw, req, http.StatusOK)
+	case providers.ErrTokenRevoked:
+		p.sessionStore.ClearSession(rw, req)
+		p.SignInPage(rw, req, http.StatusOK)
 	case sessions.ErrLifetimeExpired, sessions.ErrInvalidSession:
 		p.sessionStore.ClearSession(rw, req)
 		p.SignInPage(rw, req, http.StatusOK)

--- a/internal/proxy/oauthproxy.go
+++ b/internal/proxy/oauthproxy.go
@@ -679,6 +679,9 @@ func (p *OAuthProxy) Proxy(rw http.ResponseWriter, req *http.Request) {
 			// We know the user is not authorized for the request, we show them a forbidden page
 			p.ErrorPage(rw, req, http.StatusForbidden, "Forbidden", "You're not authorized to view this page")
 			return
+		case providers.ErrTokenRevoked:
+			p.ErrorPage(rw, req, http.StatusUnauthorized, "Unauthorized", "Token Expired or Revoked")
+			return
 		default:
 			logger.Error(err, "unknown error authenticating user")
 			tags = append(tags, "error:internal_error")

--- a/internal/proxy/providers/sso.go
+++ b/internal/proxy/providers/sso.go
@@ -31,6 +31,7 @@ var (
 var (
 	ErrMissingRefreshToken     = errors.New("missing refresh token")
 	ErrAuthProviderUnavailable = errors.New("auth provider unavailable")
+	ErrTokenRevoked            = errors.New("token revoked or expired")
 )
 
 var userAgentString string
@@ -321,6 +322,8 @@ func (p *SSOProvider) redeemRefreshToken(refreshToken string) (token string, exp
 	if resp.StatusCode != http.StatusCreated {
 		if isProviderUnavailable(resp.StatusCode) {
 			err = ErrAuthProviderUnavailable
+		} else if resp.StatusCode == http.StatusUnauthorized {
+			err = ErrTokenRevoked
 		} else {
 			err = fmt.Errorf("got %d from %q %s", resp.StatusCode, p.RefreshURL.String(), body)
 		}


### PR DESCRIPTION
## Problem

We're not catching the right error within the `oktaRequest` function, causing expired refresh tokens to be categorised under an 'unknown' error type. This results in an unclear and awkward UX in cases where the refresh token has expired. 

## Solution

Fix the error string we're searching for, and improve the general UX around this error case a little bit to provide users with a sensible error and an option to sign back in. 

## Notes

The TTL of a refresh token in Okta is easily and commonly customised, whereas the TTL of a refresh token within Google is set at 6 months by default. This has meant we've ran into this error a little bit more frequently with the Okta provider which is why we're fleshing out the UX a bit. (This error is generally unseen when the Google provider is being used)