### PR TITLE
sso_proxy: add test for websockets and update docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 defaults: &defaults
   docker:
-    - image: circleci/golang:1.11
+    - image: circleci/golang:1.12
   working_directory: /go/src/github.com/buzzfeed/sso
 
 attach_workspace: &attach_workspace

--- a/docs/sso_config.md
+++ b/docs/sso_config.md
@@ -178,6 +178,9 @@ honored as valid. The grace period ends either after the TTL expires or when
 * The grace period defined by `grace_period_ttl` is granted on a per-user basis,
   starting from the first failure to authenticate.
 
+### Websockets
+SSO supports upstreams that use websockets, providing the upstream has a positive flush interval (`flush_interval`) set.
+
 
 ### `sso_proxy` Endpoints
 * `/` - Begins the proxy process, attempting to authenticate the session cookie, redirecting to `sso-authenticator` if there is no cookie or an invalid one.

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ require (
 	github.com/benbjohnson/clock v0.0.0-20161215174838-7dc76406b6d3
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/datadog/datadog-go v0.0.0-20180822151419-281ae9f2d895
+	github.com/gorilla/websocket v1.4.0
 	github.com/imdario/mergo v0.3.7
 	github.com/kelseyhightower/envconfig v1.3.0
 	github.com/mccutchen/go-httpbin v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -100,6 +100,7 @@ github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/gorilla/handlers v1.4.0/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/mux v1.7.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=


### PR DESCRIPTION
## Problem

We've recently introduced support for websockets, however we didn't include any tests or documentation updates in the initial pull request.
## Solution

Add in a couple of simple tests and documentation updates. Also, the docker golang image that CircleCI uses has been updated to `1.12` to bring it in line with SSO's go version (required for websocket support)
