### PR TITLE
release_drafter: add basic config and template for releases

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,23 @@
+name-template: 'v$NEXT_PATCH_VERSION'
+tag-template: 'v$NEXT_PATCH_VERSION'
+change-template: '*#$NUMBER - $TITLE'
+branches: master
+categories:
+  - title: 'Features 🚀'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: 'Bug Fixes 🐛'
+    labels:
+      - 'bugfix'
+      - 'bug'
+  - title: 'Documentation 📖'
+    label:
+      - 'documentation'
+template: |
+  ## What’s Changed
+
+  $CHANGES
+
+  Release Contributors: $CONTRIBUTORS
+


### PR DESCRIPTION
## Problem
Creating and publishing a release right now is a very manual task that can, depending on the amount of merges, take a considerably long time to prepare. 

We'd like to improve this workflow to not only make it less time consuming when releases are worked on, but to help encourage more frequent releases as required by making the overall process _easier_. This change focuses on the actual creation of a release draft.

## Solution
By using https://github.com/toolmantim/release-drafter, we can largely automate the process of formulating a release draft by having it automatically and continuously populate a draft as and when pull requests are merged.

## Notes
The draft that this creates is slightly different to what we've been using in the past, however I think this should work fine instead! (it might require some tweaks along the way)
