### PR TITLE
sso_*: allow group validator to be used standalone

### DIFF
--- a/internal/pkg/options/email_group_validator.go
+++ b/internal/pkg/options/email_group_validator.go
@@ -22,8 +22,6 @@ type EmailGroupValidator struct {
 
 // NewEmailGroupValidator takes in a Provider object and a list of groups, and returns a Validator object.
 // The validator can be used to validate that the session.Email:
-// - if an empty list is passed in in place of a list of groups, all session.Emails will be considered valid
-//   regardless of group membership with that particular Provider.
 // - according to the Provider that was passed in, is a member of one of the originally passed in groups.
 // If valid, nil is returned in place of an error.
 func NewEmailGroupValidator(provider providers.Provider, allowedGroups []string) EmailGroupValidator {
@@ -34,10 +32,6 @@ func NewEmailGroupValidator(provider providers.Provider, allowedGroups []string)
 }
 
 func (v EmailGroupValidator) Validate(session *sessions.SessionState) error {
-	if len(v.AllowedGroups) == 0 {
-		return nil
-	}
-
 	err := v.validate(session)
 	if err != nil {
 		return err

--- a/internal/proxy/options.go
+++ b/internal/proxy/options.go
@@ -199,13 +199,13 @@ func (o *Options) Validate() error {
 				o.TCPWriteTimeout = uc.Timeout
 			}
 
-			if len(uc.AllowedEmailDomains) == 0 && len(uc.AllowedEmailAddresses) == 0 {
+			if len(uc.AllowedEmailDomains) == 0 && len(uc.AllowedEmailAddresses) == 0 && len(uc.AllowedGroups) == 0 {
 				invalidUpstreams = append(invalidUpstreams, uc.Service)
 			}
 		}
 		if len(invalidUpstreams) != 0 {
 			msgs = append(msgs, fmt.Sprintf(
-				"missing setting: DEFAULT_ALLOWED_EMAIL_DOMAINS or DEFAULT_ALLOWED_EMAIL_ADDRESSES in either environment or upstream config in the following upstreams: %v",
+				"missing setting: ALLOWED_EMAIL_DOMAINS, ALLOWED_EMAIL_ADDRESSES, ALLOWED_GROUPS default in environment or override in upstream config in the following upstreams: %v",
 				invalidUpstreams))
 		}
 	}

--- a/internal/proxy/options_test.go
+++ b/internal/proxy/options_test.go
@@ -59,7 +59,7 @@ func TestNewOptions(t *testing.T) {
 		"missing setting: client-secret",
 		"missing setting: statsd-host",
 		"missing setting: statsd-port",
-		"missing setting: DEFAULT_ALLOWED_EMAIL_DOMAINS or DEFAULT_ALLOWED_EMAIL_ADDRESSES in either environment or upstream config in the following upstreams: [testService]",
+		"missing setting: ALLOWED_EMAIL_DOMAINS, ALLOWED_EMAIL_ADDRESSES, ALLOWED_GROUPS default in environment or override in upstream config in the following upstreams: [testService]",
 		"Invalid value for COOKIE_SECRET; must decode to 32 or 64 bytes, but decoded to 0 bytes",
 	})
 	testutil.Equal(t, expected, err.Error())

--- a/internal/proxy/providers/sso.go
+++ b/internal/proxy/providers/sso.go
@@ -181,9 +181,6 @@ func (p *SSOProvider) ValidateGroup(email string, allowedGroups []string, access
 
 	logger.WithUser(email).WithAllowedGroups(allowedGroups).Info("validating groups")
 	inGroups := []string{}
-	if len(allowedGroups) == 0 {
-		return inGroups, true, nil
-	}
 
 	userGroups, err := p.UserGroups(email, allowedGroups, accessToken)
 	if err != nil {

--- a/internal/proxy/providers/sso_test.go
+++ b/internal/proxy/providers/sso_test.go
@@ -144,11 +144,11 @@ func TestSSOProviderGroups(t *testing.T) {
 		ProfileStatus    int
 	}{
 		{
-			Name:             "valid when no group id set",
+			Name:             "invalid when no group id set",
 			Email:            "michael.bland@gsa.gov",
 			Groups:           []string{},
 			ProxyGroupIds:    []string{},
-			ExpectedValid:    true,
+			ExpectedValid:    false,
 			ExpectedInGroups: []string{},
 			ExpectError:      nil,
 		},
@@ -311,7 +311,7 @@ func TestSSOProviderValidateSessionState(t *testing.T) {
 		ExpectedValid    bool
 	}{
 		{
-			Name: "valid when no group id set",
+			Name: "invalid when no group id set",
 			SessionState: &sessions.SessionState{
 				AccessToken: "abc",
 				Email:       "michael.bland@gsa.gov",
@@ -319,7 +319,7 @@ func TestSSOProviderValidateSessionState(t *testing.T) {
 			ProviderResponse: http.StatusOK,
 			Groups:           []string{},
 			ProxyGroupIds:    []string{},
-			ExpectedValid:    true,
+			ExpectedValid:    false,
 		},
 		{
 			Name: "invalid when response is is not 200",

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -47,7 +47,9 @@ func New(opts *Options) (*SSOProxy, error) {
 			validators = append(validators, options.NewEmailDomainValidator(upstreamConfig.AllowedEmailDomains))
 		}
 
-		validators = append(validators, options.NewEmailGroupValidator(provider, upstreamConfig.AllowedGroups))
+		if len(upstreamConfig.AllowedGroups) != 0 {
+			validators = append(validators, options.NewEmailGroupValidator(provider, upstreamConfig.AllowedGroups))
+		}
 
 		optFuncs = append(optFuncs,
 			SetProvider(provider),


### PR DESCRIPTION
## Problem

We require either `allowed_email_addresses` or `allowed_email_domains` to be passed in either as a default or for each upstream, however this limits the usability of email groups as a functional validator. It's difficult to validate a user based on groups alone if you also have to specify email addresses or email domains, for example -- it requires work arounds which should be avoided.

## Solution

Require `allowed_email_addresses`, `allowed_email_domains` _OR_ `allowed_groups` instead. This means the email group validator can still be used simultaneously with others, but also standalone which allows for a sometimes more expected workflow.

## Notes

This PR also removes functionality that means if an empty list of groups is passed in to the validator then the user is automatically 'valid' per the group validator. If a group validator can be the _only_ validator, I don't think this logic makes sense (however there may be other historic reasons why this was allowed that I'm unaware of)