### PR TITLE
validator pkg: control when each validator is ran

### DIFF
--- a/internal/auth/authenticator.go
+++ b/internal/auth/authenticator.go
@@ -226,7 +226,7 @@ func (p *Authenticator) authenticate(rw http.ResponseWriter, req *http.Request) 
 		}
 	}
 
-	errors := options.RunValidators(p.Validators, session)
+	errors := options.RunValidators(p.Validators, options.AuthenticatorFlow, session)
 	if len(errors) == len(p.Validators) {
 		logger.WithUser(session.Email).Info(
 			fmt.Sprintf("permission denied: unauthorized: %q", errors))
@@ -582,7 +582,7 @@ func (p *Authenticator) getOAuthCallback(rw http.ResponseWriter, req *http.Reque
 	// - for p.Validator see validator.go#newValidatorImpl for more info
 	// - for p.provider.ValidateGroup see providers/google.go#ValidateGroup for more info
 
-	errors := options.RunValidators(p.Validators, session)
+	errors := options.RunValidators(p.Validators, options.AuthenticatorFlow, session)
 	if len(errors) == len(p.Validators) {
 		tags := append(tags, "error:invalid_email")
 		p.StatsdClient.Incr("application_error", tags, 1.0)

--- a/internal/pkg/options/email_address_validator.go
+++ b/internal/pkg/options/email_address_validator.go
@@ -41,6 +41,13 @@ func NewEmailAddressValidator(allowedEmails []string) EmailAddressValidator {
 	}
 }
 
+// Flags defines which flows this validator should be ran against.
+func (v EmailAddressValidator) Flags() validatorFlag {
+	return OAuthCallbackFlow | ProxyAuthFlow | AuthenticatorFlow
+}
+
+// Validate attempts to validate the session, returning an error for invalid
+// sessions, or nil for valid sessions.
 func (v EmailAddressValidator) Validate(session *sessions.SessionState) error {
 	if session.Email == "" {
 		return ErrInvalidEmailAddress

--- a/internal/pkg/options/email_domain_validator.go
+++ b/internal/pkg/options/email_domain_validator.go
@@ -44,6 +44,13 @@ func NewEmailDomainValidator(allowedDomains []string) *EmailDomainValidator {
 	}
 }
 
+// Flags defines which flows this validator should be ran against.
+func (v *EmailDomainValidator) Flags() validatorFlag {
+	return OAuthCallbackFlow | ProxyAuthFlow | AuthenticatorFlow
+}
+
+// Validate attempts to validate the session, returning an error for invalid
+// sessions, or nil for valid sessions.
 func (v *EmailDomainValidator) Validate(session *sessions.SessionState) error {
 	if session.Email == "" {
 		return ErrInvalidEmailAddress

--- a/internal/pkg/options/email_group_validator.go
+++ b/internal/pkg/options/email_group_validator.go
@@ -31,6 +31,13 @@ func NewEmailGroupValidator(provider providers.Provider, allowedGroups []string)
 	}
 }
 
+// Flags defines which flows this validator should be ran against.
+func (v EmailGroupValidator) Flags() validatorFlag {
+	return OAuthCallbackFlow
+}
+
+// Validate attempts to validate the session, returning an error for invalid
+// sessions, or nil for valid sessions.
 func (v EmailGroupValidator) Validate(session *sessions.SessionState) error {
 	err := v.validate(session)
 	if err != nil {

--- a/internal/pkg/options/mock_validator.go
+++ b/internal/pkg/options/mock_validator.go
@@ -20,6 +20,10 @@ func NewMockValidator(result bool) MockValidator {
 	}
 }
 
+func (v MockValidator) Flags() validatorFlag {
+	return OAuthCallbackFlow | ProxyAuthFlow | AuthenticatorFlow
+}
+
 func (v MockValidator) Validate(session *sessions.SessionState) error {
 	if v.Result {
 		return nil

--- a/internal/pkg/options/validators.go
+++ b/internal/pkg/options/validators.go
@@ -13,20 +13,40 @@ var (
 	ErrValidationError     = errors.New("Error during validation")
 )
 
+type validatorFlag int32
+
+// We don't necessarily always want each type of validator to run,
+// so this allows us to specify the 'flow' the validator is being used in.
+// Which 'flow' the validator will run in is defined within the validator
+// itself.
+const (
+	OAuthCallbackFlow validatorFlag = 1 << iota
+	ProxyAuthFlow
+	AuthenticatorFlow
+)
+
 type Validator interface {
 	Validate(*sessions.SessionState) error
+	Flags() validatorFlag
 }
 
-// RunValidators runs each passed in validator and returns a slice of errors. If an
-// empty slice is returned, it can be assumed all passed in validators were successful.
-func RunValidators(validators []Validator, session *sessions.SessionState) []error {
+// RunValidators takes in a list of validators, a flag, and a session. The flag is used
+// to prevent certain validators from running during certain flows. If the passed in flag
+// deems the validator to be 'active' for this flow, then the validator is ran.
+//
+// It retuns a slice of errors found within all validators that were ran. If an empty slice
+// is returned we can assume all validators passed.
+func RunValidators(validators []Validator, flag validatorFlag, session *sessions.SessionState) []error {
 	validatorErrors := make([]error, 0, len(validators))
 
-	for _, validator := range validators {
-		err := validator.Validate(session)
-		if err != nil {
-			validatorErrors = append(validatorErrors, err)
+	for _, v := range validators {
+		if (v.Flags() & flag) > 0 {
+			err := v.Validate(session)
+			if err != nil {
+				validatorErrors = append(validatorErrors, err)
+			}
 		}
 	}
+
 	return validatorErrors
 }

--- a/internal/proxy/oauthproxy.go
+++ b/internal/proxy/oauthproxy.go
@@ -569,7 +569,7 @@ func (p *OAuthProxy) OAuthCallback(rw http.ResponseWriter, req *http.Request) {
 	//
 	// set cookie, or deny
 
-	errors := options.RunValidators(p.Validators, session)
+	errors := options.RunValidators(p.Validators, options.OAuthCallbackFlow, session)
 	if len(errors) == len(p.Validators) {
 		tags = append(tags, "error:validation_failed")
 		p.StatsdClient.Incr("application_error", tags, 1.0)
@@ -781,7 +781,7 @@ func (p *OAuthProxy) Authenticate(rw http.ResponseWriter, req *http.Request) (er
 		}
 	}
 
-	errors := options.RunValidators(p.Validators, session)
+	errors := options.RunValidators(p.Validators, options.ProxyAuthFlow, session)
 	if len(errors) == len(p.Validators) {
 		tags = append(tags, "error:validation_failed")
 		p.StatsdClient.Incr("application_error", tags, 1.0)


### PR DESCRIPTION
## Problem

With the validator abstraction work that was recently done we inadvertently started to run group validations more than we used to.

Depending on the request volume flowing through SSO running the group check _again_ can cause issues with upstream providers. 

## Solution

We don't need to validate the groups again here. This pull request adds a feature to the validator package that allows us to pass in a flag whenever calling the `RunValidators()` function that will determine which validators we want to run in that flow. 

This gives us more flexibility to control when specific validators should or shouldn't be ran.

## Notes

Now that the group membership check is an official 'validator' within sso-proxy it's ran each time we call `RunValidators()`, whereas before when running the equivalent function the group check wasn't part of this.

Specifically, here: https://github.com/buzzfeed/sso/blob/9019d4f79b453b50882213baa8549d40852daaf7/internal/proxy/oauthproxy.go#L784 

Previously, we were only checking email address/domains as the group check is ran just above that when refreshing or validating the session: https://github.com/buzzfeed/sso/blob/9019d4f79b453b50882213baa8549d40852daaf7/internal/proxy/oauthproxy.go#L731 & https://github.com/buzzfeed/sso/blob/9019d4f79b453b50882213baa8549d40852daaf7/internal/proxy/oauthproxy.go#L762
