### PR TITLE
sso_proxy: reduce amount of group validations

### DIFF
--- a/internal/auth/providers/okta.go
+++ b/internal/auth/providers/okta.go
@@ -199,7 +199,7 @@ func (p *OktaProvider) oktaRequest(method, endpoint string, params url.Values, t
 	if resp.StatusCode != http.StatusOK {
 		p.StatsdClient.Incr("provider.error", tags, 1.0)
 		logger.WithHTTPStatus(resp.StatusCode).WithEndpoint(stripToken(endpoint)).WithResponseBody(
-			respBody).Info()
+			respBody).Error("non-200 response returned from Okta")
 		switch resp.StatusCode {
 		case 400:
 			var response struct {

--- a/internal/pkg/options/email_domain_validator.go
+++ b/internal/pkg/options/email_domain_validator.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	_ Validator = &EmailDomainValidator{}
+	_ Validator = EmailDomainValidator{}
 
 	// These error message should be formatted in such a way that is appropriate
 	// for display to the end user.
@@ -28,7 +28,7 @@ type EmailDomainValidator struct {
 // - if the originally passed in list of domains consists only of "*", then all emails
 //   are considered valid based on their domain.
 // If valid, nil is returned in place of an error.
-func NewEmailDomainValidator(allowedDomains []string) *EmailDomainValidator {
+func NewEmailDomainValidator(allowedDomains []string) EmailDomainValidator {
 	emailDomains := make([]string, 0, len(allowedDomains))
 
 	for _, domain := range allowedDomains {
@@ -39,12 +39,12 @@ func NewEmailDomainValidator(allowedDomains []string) *EmailDomainValidator {
 			emailDomains = append(emailDomains, emailDomain)
 		}
 	}
-	return &EmailDomainValidator{
+	return EmailDomainValidator{
 		AllowedDomains: emailDomains,
 	}
 }
 
-func (v *EmailDomainValidator) Validate(session *sessions.SessionState) error {
+func (v EmailDomainValidator) Validate(session *sessions.SessionState) error {
 	if session.Email == "" {
 		return ErrInvalidEmailAddress
 	}
@@ -64,7 +64,7 @@ func (v *EmailDomainValidator) Validate(session *sessions.SessionState) error {
 	return nil
 }
 
-func (v *EmailDomainValidator) validate(session *sessions.SessionState) error {
+func (v EmailDomainValidator) validate(session *sessions.SessionState) error {
 	email := strings.ToLower(session.Email)
 	for _, domain := range v.AllowedDomains {
 		if strings.HasSuffix(email, domain) {


### PR DESCRIPTION
## Problem

With the validator abstraction work that was recently done we inadvertently started to run group validations for each authenticated request. See 'Notes' section for specific details.

This increased volume of requests increases the potential to cause extra strain on upstream providers

## Solution

We don't need to validate the groups again here. This pull request brings us closer to previous functionality where we re-validate group membership after refreshing or validating the session, and re-validate email domains and addresses upon each request.

## Notes

- Now that the group membership check is an official 'validator' within sso-proxy it's ran each time we call `RunValidators()`. 

   The problematic call in question: https://github.com/buzzfeed/sso/blob/9019d4f79b453b50882213baa8549d40852daaf7/internal/proxy/oauthproxy.go#L784 

   Previously, we were only checking email address/domains here, with the group check being ran just above that when refreshing or validating the session: https://github.com/buzzfeed/sso/blob/9019d4f79b453b50882213baa8549d40852daaf7/internal/proxy/oauthproxy.go#L731 & https://github.com/buzzfeed/sso/blob/9019d4f79b453b50882213baa8549d40852daaf7/internal/proxy/oauthproxy.go#L762

- An alternative solution to https://github.com/buzzfeed/sso/pull/266
- Also included in this is a change to the group validator (it's no longer used as a pointer). Largely to bring it in line with the other validators.