### PR TITLE
bump golang to 1.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #
 # install golang dependencies & build binaries
 # =============================================================================
-FROM golang:1.12 AS build
+FROM golang:1.13 AS build
 
 ENV GOFLAGS='-ldflags=-s -ldflags=-w'
 ENV CGO_ENABLED=0


### PR DESCRIPTION
Signed-off-by: Daniel Sutton <daniel@ducksecops.uk>

## Problem

Not using latest golang

## Solution

update dockerfile to use golang 1.13

## Notes

Other pertinent information. Examples: a walkthrough of how the solution might work, why this solution is optimal compared to other possible solutions, or further TODOs beyond this PR.
