### PR TITLE
fillcache pkg: trigger cache update immediately

### DIFF
--- a/internal/pkg/groups/fillcache.go
+++ b/internal/pkg/groups/fillcache.go
@@ -19,7 +19,7 @@ type MemberSetCache interface {
 	// Get returns a MemberSet from the cache
 	Get(string) (MemberSet, bool)
 	// Update updates the MemberSet of a given key, return a boolean updated value, and and error
-	Update(string) (bool, error)
+	Update(string) bool
 	// RefreshLoop starts an update refresh loop for a given key and returns a boolean value of it was started
 	RefreshLoop(string) bool
 	// Stop is a function to stop all goroutines that may have been spun up for the cache.
@@ -71,11 +71,14 @@ func (c *FillCache) Get(group string) (MemberSet, bool) {
 // Update recomputes the value for the given key, unless another goroutine is
 // already computing the value, and returns a bool indicating whether the value
 // was updated
-func (c *FillCache) Update(group string) (bool, error) {
+func (c *FillCache) Update(group string) bool {
+	logger := log.NewLogEntry()
+	logger.WithUserGroup(group).Info("updating fill cache")
+
 	c.mu.Lock()
 	if _, waiting := c.inflight[group]; waiting {
 		c.mu.Unlock()
-		return false, nil
+		return false
 	}
 
 	c.inflight[group] = struct{}{}
@@ -88,30 +91,16 @@ func (c *FillCache) Update(group string) (bool, error) {
 
 	if err == nil {
 		c.cache[group] = val
-		return true, nil
-	}
-	return false, err
-}
-
-// update wraps the Update method, adding instrumentation
-func (c *FillCache) update(group string) {
-	logger := log.NewLogEntry()
-	logger.WithUserGroup(group).Info("updating fill cache")
-
-	updated, err := c.Update(group)
-	if err != nil {
-		c.StatsdClient.Incr("groups_cache.error",
-			[]string{
-				fmt.Sprintf("group:%s", group),
-				fmt.Sprintf("error:%s", err),
-			}, 1.0)
-		logger.WithUserGroup(group).Error(
-			err, "error updating fill cache")
+		return true
 	}
 
-	if !updated {
-		logger.WithUserGroup(group).Info("cache was not updated")
-	}
+	c.StatsdClient.Incr("groups_cache.error",
+		[]string{
+			fmt.Sprintf("group:%s", group),
+			fmt.Sprintf("error:%s", err),
+		}, 1.0)
+	logger.WithUserGroup(group).Error(err, "error updating fill cache")
+	return false
 }
 
 // RefreshLoop runs in a separate goroutine for the key in the cache and
@@ -147,14 +136,20 @@ func (c *FillCache) RefreshLoop(group string) bool {
 
 		// we update the cache once before looping to ensure the cache is filled immediately,
 		// instead of only after c.refreshTTL
-		c.update(group)
+		updated := c.Update(group)
+		if !updated {
+			logger.WithUserGroup(group).Info("cache was not updated")
+		}
 
 		for {
 			select {
 			case <-c.stopCh:
 				return
 			case <-ticker.C:
-				c.update(group)
+				updated = c.Update(group)
+				if !updated {
+					logger.WithUserGroup(group).Info("cache was not updated")
+				}
 			}
 		}
 	}()

--- a/internal/pkg/groups/fillcache.go
+++ b/internal/pkg/groups/fillcache.go
@@ -127,6 +127,7 @@ func (c *FillCache) RefreshLoop(group string) bool {
 
 	ticker := time.NewTicker(c.refreshTTL)
 	go func() {
+		logger := log.NewLogEntry()
 		// cleanup if this goroutine exits
 		defer func() {
 			c.mu.Lock()

--- a/internal/pkg/groups/fillcache.go
+++ b/internal/pkg/groups/fillcache.go
@@ -18,9 +18,9 @@ const (
 type MemberSetCache interface {
 	// Get returns a MemberSet from the cache
 	Get(string) (MemberSet, bool)
-	// Update updates the MemberSet of a given key, return a boolean updated value, and and error
+	// Update updates the MemberSet of a given key and returns a boolean value indicating whether the value was updated or not.
 	Update(string) bool
-	// RefreshLoop starts an update refresh loop for a given key and returns a boolean value of it was started
+	// RefreshLoop starts an update refresh loop for a given key and returns a boolean value indicating whether a refresh loop has been started or not
 	RefreshLoop(string) bool
 	// Stop is a function to stop all goroutines that may have been spun up for the cache.
 	Stop()

--- a/internal/pkg/groups/fillcache_test.go
+++ b/internal/pkg/groups/fillcache_test.go
@@ -14,34 +14,27 @@ func testFillFunc(members MemberSet, fillError error) func(string) (MemberSet, e
 
 func TestFillCacheUpdate(t *testing.T) {
 	testCases := []struct {
-		name          string
-		members       MemberSet
-		fillError     error
-		updated       bool
-		expectedError bool
+		name      string
+		members   MemberSet
+		fillError error
+		updated   bool
 	}{
 		{
-			name:    "update to empty cache, no fill errors",
+			name:    "successful update to empty cache",
 			members: MemberSet{"a": {}, "b": {}, "c": {}},
 			updated: true,
 		},
 		{
-			name:          "update with fill function error",
-			fillError:     fmt.Errorf("fill error"),
-			expectedError: true,
+			name:      "unsuccessful update to cache",
+			fillError: fmt.Errorf("fill error"),
+			updated:   false,
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			fillCache := NewFillCache(testFillFunc(tc.members, tc.fillError), time.Hour)
 			defer fillCache.Stop()
-			ok, err := fillCache.Update("groupKey")
-			if err == nil && tc.expectedError {
-				t.Errorf("expected error but err was nil")
-			}
-			if err != nil && !tc.expectedError {
-				t.Errorf("unexpected error %s", err)
-			}
+			ok := fillCache.Update("groupKey")
 			if tc.updated != ok {
 				t.Errorf("expected updated to be %v but was %v", tc.updated, ok)
 			}

--- a/internal/pkg/groups/fillcache_test.go
+++ b/internal/pkg/groups/fillcache_test.go
@@ -64,9 +64,20 @@ func TestRefreshLoop(t *testing.T) {
 			if tc.refreshLoopGroups != nil {
 				fillCache.refreshLoopGroups = tc.refreshLoopGroups
 			}
+
 			started := fillCache.RefreshLoop("group1")
+
 			if tc.expectedStarted != started {
 				t.Errorf("expected started to be %v but was %v", tc.expectedStarted, started)
+			}
+
+			if tc.expectedStarted {
+				// wait briefly to allow the cache to be updated
+				time.Sleep(50 * time.Millisecond)
+				_, ok := fillCache.Get("group1")
+				if !ok {
+					t.Errorf("expected the group cache to be updated immediately")
+				}
 			}
 
 		})

--- a/internal/pkg/groups/mock_cache.go
+++ b/internal/pkg/groups/mock_cache.go
@@ -5,7 +5,6 @@ type MockCache struct {
 	ListMembershipsFunc func(string) (MemberSet, bool)
 	Exists              bool
 	Updated             bool
-	UpdateError         error
 	Refreshed           bool
 }
 
@@ -15,8 +14,8 @@ func (mc *MockCache) Get(group string) (MemberSet, bool) {
 }
 
 // Update updates the cache
-func (mc *MockCache) Update(string) (bool, error) {
-	return mc.Updated, mc.UpdateError
+func (mc *MockCache) Update(string) bool {
+	return mc.Updated
 }
 
 // RefreshLoop returns a boolean of if the refresh loop is refreshed


### PR DESCRIPTION
## Problem
The fillcache package is what we use with the Google (and soon to be Cognito) providers to keep group membership cached. 

Once a request goes through to `sso_auth` to validate a users group membership, the `ValidateGroup` function looks in the local cache for the relevant groups:
https://github.com/buzzfeed/sso/blob/14f2a962d995bbd4b69da4420df5fe53dc3468c2/internal/auth/providers/google.go#L366-L370 
If the group doesn't exist in the cache, it triggers a refresh of the cache which in turn kicks off a goroutine to keep the group cache up to date (based off an input TTL).

Right now, the triggered goroutine only fills the cache _after_ the given TTL, not immediately. Any subsequent calls to `ValidateGroupMembership` between the first call, and the first tick of `ttl` won’t have the groups cached.
## Solution

Break out the logic that the goroutine uses to fill the cache into a separate method, and call it once _before_ the loop, and then upon each tick of `ttl`. 

Going to look at updating this PR with some logging examples to better verify the bug + expected behaviour 

## Notes
- There are few different ways we could implement this, but the last commit includes one that is perhaps most _clear_ 