### PR TITLE
sso: update go modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ ENV GO111MODULE=on
 WORKDIR /go/src/github.com/buzzfeed/sso
 
 COPY . .
-RUN cd cmd/sso-auth && go build --mod=readonly -o /bin/sso-auth
-RUN cd cmd/sso-proxy && go build --mod=readonly -o /bin/sso-proxy
+RUN cd cmd/sso-auth && go build -mod=readonly -o /bin/sso-auth
+RUN cd cmd/sso-proxy && go build -mod=readonly -o /bin/sso-proxy
 
 # =============================================================================
 # final stage

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ ENV GO111MODULE=on
 WORKDIR /go/src/github.com/buzzfeed/sso
 
 COPY . .
-RUN cd cmd/sso-auth && go build -o /bin/sso-auth
-RUN cd cmd/sso-proxy && go build -o /bin/sso-proxy
+RUN cd cmd/sso-auth && go build --mod=readonly -o /bin/sso-auth
+RUN cd cmd/sso-proxy && go build --mod=readonly -o /bin/sso-proxy
 
 # =============================================================================
 # final stage

--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,12 @@ build: dist/sso-auth dist/sso-proxy
 dist/sso-auth:
 	mkdir -p dist
 	go generate ./...
-	go build --mod=readonly -o dist/sso-auth ./cmd/sso-auth
+	go build -mod=readonly -o dist/sso-auth ./cmd/sso-auth
 
 dist/sso-proxy:
 	mkdir -p dist
 	go generate ./...
-	go build --mod=readonly -o dist/sso-proxy ./cmd/sso-proxy
+	go build -mod=readonly -o dist/sso-proxy ./cmd/sso-proxy
 
 tools:
 	go get golang.org/x/lint/golint

--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,12 @@ build: dist/sso-auth dist/sso-proxy
 dist/sso-auth:
 	mkdir -p dist
 	go generate ./...
-	go build -o dist/sso-auth ./cmd/sso-auth
+	go build --mod=readonly -o dist/sso-auth ./cmd/sso-auth
 
 dist/sso-proxy:
 	mkdir -p dist
 	go generate ./...
-	go build -o dist/sso-proxy ./cmd/sso-proxy
+	go build --mod=readonly -o dist/sso-proxy ./cmd/sso-proxy
 
 tools:
 	go get golang.org/x/lint/golint

--- a/go.mod
+++ b/go.mod
@@ -14,9 +14,10 @@ require (
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/rakyll/statik v0.1.6
 	github.com/sirupsen/logrus v1.4.2
+	golang.org/x/net v0.0.0-20190620200207-3b0461eec859 // indirect
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
-	golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522
+	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7
 	google.golang.org/api v0.5.0
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -309,6 +309,8 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190501004415-9ce7a6920f09/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65 h1:+rhAzEzT3f4JtomfC371qB+0Ola2caSKcY69NUBZrRQ=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
+golang.org/x/net v0.0.0-20190620200207-3b0461eec859 h1:R/3boaszxrf1GEUWTVDzSKVwLmSJpwZ1yqXm8j0v2QI=
+golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 h1:SVwTIAaPC2U/AvvLNZ2a7OVsmBpC8L5BlwK1whH3hm0=
@@ -361,8 +363,8 @@ golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBn
 golang.org/x/tools v0.0.0-20190530171427-2b03ca6e44eb/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190603231351-8aaa1484dc10 h1:9LyHDLeGJwq8p/x0xbF8aG63cLC6EDjlNbGYc7dacDc=
 golang.org/x/tools v0.0.0-20190603231351-8aaa1484dc10/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
-golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522 h1:bhOzK9QyoD0ogCnFro1m2mz41+Ib0oOhfJnBp5MR4K4=
-golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.5.0 h1:lj9SyhMzyoa38fgFF0oO2T6pjs5IzkLPKfVtxpyCRMM=
 google.golang.org/api v0.5.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=


### PR DESCRIPTION
## Problem
Updates to certain go modules are required. This is starting to cause errors with new builds: https://circleci.com/gh/buzzfeed/sso/2185?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

## Solution

Running https://github.com/buzzfeed/sso/blob/master/scripts/test locally edited `go.mod` and `go.sum` files as required.
