### PR TITLE
sso_proxy: fix request signer hash panic

### DIFF
--- a/internal/proxy/request_signer.go
+++ b/internal/proxy/request_signer.go
@@ -38,7 +38,7 @@ var signingKeyHeader = "kid"
 // RequestSigner exposes an interface for digitally signing requests using an RSA private key.
 // See comments for the Sign() method below, for more on how this signature is constructed.
 type RequestSigner struct {
-	newHasher       func() hash.Hash
+	newHasher    func() hash.Hash
 	signingKey   crypto.Signer
 	publicKeyStr string
 	publicKeyID  string

--- a/internal/proxy/request_signer.go
+++ b/internal/proxy/request_signer.go
@@ -38,7 +38,7 @@ var signingKeyHeader = "kid"
 // RequestSigner exposes an interface for digitally signing requests using an RSA private key.
 // See comments for the Sign() method below, for more on how this signature is constructed.
 type RequestSigner struct {
-	hasher       func() hash.Hash
+	newHasher       func() hash.Hash
 	signingKey   crypto.Signer
 	publicKeyStr string
 	publicKeyID  string
@@ -79,7 +79,7 @@ func NewRequestSigner(signingKeyPemStr string) (*RequestSigner, error) {
 	keyHash = hasher.Sum(keyHash)
 
 	return &RequestSigner{
-		hasher:       func() hash.Hash { return sha256.New() },
+		newHasher:       func() hash.Hash { return sha256.New() },
 		signingKey:   privateKey,
 		publicKeyStr: string(publicKeyPEM),
 		publicKeyID:  hex.EncodeToString(keyHash),
@@ -168,7 +168,7 @@ func (signer RequestSigner) Sign(req *http.Request) error {
 
 	// Generate hash of the document buffer.
 	var documentHash []byte
-	hasher := signer.hasher()
+	hasher := signer.newHasher()
 	hasher.Reset()
 	_, _ = hasher.Write([]byte(repr))
 	documentHash = hasher.Sum(documentHash)

--- a/internal/proxy/request_signer.go
+++ b/internal/proxy/request_signer.go
@@ -38,7 +38,7 @@ var signingKeyHeader = "kid"
 // RequestSigner exposes an interface for digitally signing requests using an RSA private key.
 // See comments for the Sign() method below, for more on how this signature is constructed.
 type RequestSigner struct {
-	hasher       hash.Hash
+	hasher       *hash.Hash
 	signingKey   crypto.Signer
 	publicKeyStr string
 	publicKeyID  string
@@ -79,7 +79,7 @@ func NewRequestSigner(signingKeyPemStr string) (*RequestSigner, error) {
 	keyHash = hasher.Sum(keyHash)
 
 	return &RequestSigner{
-		hasher:       sha256.New(),
+		hasher:       &hasher,
 		signingKey:   privateKey,
 		publicKeyStr: string(publicKeyPEM),
 		publicKeyID:  hex.EncodeToString(keyHash),
@@ -168,9 +168,12 @@ func (signer RequestSigner) Sign(req *http.Request) error {
 
 	// Generate hash of the document buffer.
 	var documentHash []byte
-	signer.hasher.Reset()
-	_, _ = signer.hasher.Write([]byte(repr))
-	documentHash = signer.hasher.Sum(documentHash)
+	// make a copy of hasher to avoid resetting the hash while multiple requests
+	// are being signed simultaneously
+	hasher := *signer.hasher
+	hasher.Reset()
+	_, _ = hasher.Write([]byte(repr))
+	documentHash = hasher.Sum(documentHash)
 
 	// Sign the documentHash with the signing key.
 	signatureBytes, err := signer.signingKey.Sign(rand.Reader, documentHash, crypto.SHA256)

--- a/internal/proxy/request_signer.go
+++ b/internal/proxy/request_signer.go
@@ -38,7 +38,7 @@ var signingKeyHeader = "kid"
 // RequestSigner exposes an interface for digitally signing requests using an RSA private key.
 // See comments for the Sign() method below, for more on how this signature is constructed.
 type RequestSigner struct {
-	hasher       *hash.Hash
+	hasher       func() hash.Hash
 	signingKey   crypto.Signer
 	publicKeyStr string
 	publicKeyID  string
@@ -79,7 +79,7 @@ func NewRequestSigner(signingKeyPemStr string) (*RequestSigner, error) {
 	keyHash = hasher.Sum(keyHash)
 
 	return &RequestSigner{
-		hasher:       &hasher,
+		hasher:       func() hash.Hash { return sha256.New() },
 		signingKey:   privateKey,
 		publicKeyStr: string(publicKeyPEM),
 		publicKeyID:  hex.EncodeToString(keyHash),
@@ -168,9 +168,7 @@ func (signer RequestSigner) Sign(req *http.Request) error {
 
 	// Generate hash of the document buffer.
 	var documentHash []byte
-	// make a copy of hasher to avoid resetting the hash while multiple requests
-	// are being signed simultaneously
-	hasher := *signer.hasher
+	hasher := signer.hasher()
 	hasher.Reset()
 	_, _ = hasher.Write([]byte(repr))
 	documentHash = hasher.Sum(documentHash)

--- a/internal/proxy/request_signer.go
+++ b/internal/proxy/request_signer.go
@@ -79,7 +79,7 @@ func NewRequestSigner(signingKeyPemStr string) (*RequestSigner, error) {
 	keyHash = hasher.Sum(keyHash)
 
 	return &RequestSigner{
-		newHasher:       func() hash.Hash { return sha256.New() },
+		newHasher:    func() hash.Hash { return sha256.New() },
 		signingKey:   privateKey,
 		publicKeyStr: string(publicKeyPEM),
 		publicKeyID:  hex.EncodeToString(keyHash),


### PR DESCRIPTION
## Problem

Occasional panics (`http: panic serving 172.17.0.16:49478: d.nx != 0`) which seem to be caused by `sso_proxy` using the same hasher for multiple requests, creating a race condition between the `hasher.Reset()` and `hasher.Write([]byte(repr))` calls.

## Solution

Instead of storing a `hash.Hash` object within the `RequestSigner`, instead store a function which creates a new `hash.Hash`. This lets each request be signed using a different Hash.
