### PR TITLE
sso_proxy: update to use `go-micro` for configuration management

### DIFF
--- a/cmd/sso-proxy/main.go
+++ b/cmd/sso-proxy/main.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/kelseyhightower/envconfig"
-
 	"github.com/buzzfeed/sso/internal/pkg/httpserver"
 	"github.com/buzzfeed/sso/internal/pkg/logging"
 	"github.com/buzzfeed/sso/internal/proxy"
@@ -21,26 +19,42 @@ func init() {
 func main() {
 	logger := logging.NewLogEntry()
 
-	opts := proxy.NewOptions()
-	err := envconfig.Process("", opts)
+	config, err := proxy.LoadConfig()
 	if err != nil {
-		logger.Error(err, "error parsing env vars into options")
+		logger.Error(err, "error loading in config from env vars")
 		os.Exit(1)
 	}
 
-	err = opts.Validate()
+	err = config.Validate()
 	if err != nil {
-		logger.Error(err, "error validating options")
+		logger.Error(err, "error validating config")
+		os.Exit(1)
+	}
+
+	sc := config.MetricsConfig.StatsdConfig
+	statsdClient, err := proxy.NewStatsdClient(sc.Host, sc.Port)
+	if err != nil {
+		logger.Error(err, "error creating statsd client")
 		os.Exit(1)
 	}
 
 	// we setup a runtime collector to emit stats
 	go func() {
-		c := collector.New(opts.StatsdClient, 30*time.Second)
+		c := collector.New(statsdClient, 30*time.Second)
 		c.Run()
 	}()
 
-	ssoProxy, err := proxy.New(opts)
+	err = proxy.SetUpstreamConfigs(
+		&config.UpstreamConfigs,
+		config.SessionConfig.CookieConfig,
+		&config.ServerConfig,
+	)
+	if err != nil {
+		logger.Error(err, "error setting upstream configs")
+		os.Exit(1)
+	}
+
+	ssoProxy, err := proxy.New(config, statsdClient)
 	if err != nil {
 		logger.Error(err, "error creating sso proxy")
 		os.Exit(1)
@@ -48,18 +62,18 @@ func main() {
 
 	loggingHandler := proxy.NewLoggingHandler(os.Stdout,
 		ssoProxy,
-		opts.RequestLogging,
-		opts.StatsdClient,
+		config.LoggingConfig,
+		statsdClient,
 	)
 
 	s := &http.Server{
-		Addr:         fmt.Sprintf(":%d", opts.Port),
-		ReadTimeout:  opts.TCPReadTimeout,
-		WriteTimeout: opts.TCPWriteTimeout,
+		Addr:         fmt.Sprintf(":%d", config.ServerConfig.Port),
+		ReadTimeout:  config.ServerConfig.TimeoutConfig.Read,
+		WriteTimeout: config.ServerConfig.TimeoutConfig.Write,
 		Handler:      loggingHandler,
 	}
 
-	if err := httpserver.Run(s, opts.ShutdownTimeout, logger); err != nil {
+	if err := httpserver.Run(s, config.ServerConfig.TimeoutConfig.Shutdown, logger); err != nil {
 		logger.WithError(err).Fatal("error running server")
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/gorilla/mux v1.7.2
 	github.com/gorilla/websocket v1.4.0
 	github.com/imdario/mergo v0.3.7
-	github.com/kelseyhightower/envconfig v1.3.0
 	github.com/mccutchen/go-httpbin v1.1.1
 	github.com/micro/go-micro v1.5.0
 	github.com/miscreant/miscreant-go v0.0.0-20181010193435-325cbd69228b

--- a/go.sum
+++ b/go.sum
@@ -150,8 +150,6 @@ github.com/joncalhoun/qson v0.0.0-20170526102502-8a9cab3a62b1/go.mod h1:DFXrEwSR
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
-github.com/kelseyhightower/envconfig v1.3.0 h1:IvRS4f2VcIQy6j4ORGIf9145T/AsUB+oY8LyvN8BXNM=
-github.com/kelseyhightower/envconfig v1.3.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/kevinburke/ssh_config v0.0.0-20180830205328-81db2a75821e/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=

--- a/internal/proxy/configuration.go
+++ b/internal/proxy/configuration.go
@@ -1,0 +1,460 @@
+package proxy
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/micro/go-micro/config"
+	"github.com/micro/go-micro/config/source/env"
+	"github.com/mitchellh/mapstructure"
+)
+
+// DefaultProxyCongig specifies all the defaults used to configure sso-proxy
+// All configuration can be set using environment variables. Below is a list of
+// configuration variables via their environment configuraiton
+//
+// SESSION_COOKIE_NAME
+// SESSION_COOKIE_SECRET
+// SESSION_COOKIE_EXPIRE
+// SESSION_COOKIE_DOMAIN
+// SESSION_COOKIE_HTTPONLY
+// SESSION_TTL_LIFETIME
+// SESSION_TTL_VALID
+// SESSION_TTL_GRACEPERIOD
+//
+// REQUESTSIGNER_KEY
+//
+// CLIENT_ID
+// CLIENT_SECRET
+//
+// SERVER_PORT
+// SERVER_TIMEOUT_SHUTDOWN
+// SERVER_TIMEOUT_READ
+// SERVER_TIMEOUT_WRITE
+//
+// METRICS_STATSD_HOST
+// METRICS_STATSD_PORT
+//
+// LOGGING_ENABLE
+//
+// UPSTREAM_DEFAULT_EMAIL_DOMAINS
+// UPSTREAM_DEFAULT_EMAIL_ADDRESSES
+// UPSTREAM_DEFAULT_GROUPS
+// UPSTREAM_DEFAULT_TIMEOUT
+// UPSTREAM_DEFAULT_TCP_RESET_DEADLINE
+// UPSTREAM_DEFAULT_PROVIDER
+// UPSTREAM_CONFIGS_FILE
+// UPSTREAM_SCHEME
+// UPSTREAM_CLUSTER
+//
+// PROVIDER_TYPE
+// PROVIDER_URL_EXTERNAL
+// PROVIDER_URL_INTERNAL
+// PROVIDER_SCOPE
+
+func DefaultProxyConfig() Configuration {
+	return Configuration{
+		ServerConfig: ServerConfig{
+			Port: 4180,
+			TimeoutConfig: TimeoutConfig{
+				Write:    30 * time.Second,
+				Read:     30 * time.Second,
+				Shutdown: 30 * time.Second,
+			},
+		},
+		ProviderConfig: ProviderConfig{
+			ProviderType: "sso",
+		},
+		SessionConfig: SessionConfig{
+			CookieConfig: CookieConfig{
+				Name:     "_sso_proxy",
+				Expire:   168 * time.Hour,
+				Secure:   true,
+				HTTPOnly: true,
+			},
+			TTLConfig: TTLConfig{
+				Lifetime:    720 * time.Hour,
+				Valid:       60 * time.Second,
+				GracePeriod: 3 * time.Hour,
+			},
+		},
+		UpstreamConfigs: UpstreamConfigs{
+			DefaultConfig: DefaultConfig{
+				Timeout:       10 * time.Second,
+				ResetDeadline: 60 * time.Second,
+				ProviderSlug:  "google",
+			},
+			Scheme: "https",
+		},
+		LoggingConfig: LoggingConfig{
+			Enable: true,
+		},
+		MetricsConfig: MetricsConfig{
+			StatsdConfig: StatsdConfig{
+				Port: 8125,
+				Host: "localhost",
+			},
+		},
+	}
+}
+
+type Validator interface {
+	Validate() error
+}
+
+var (
+	_ Validator = Configuration{}
+	_ Validator = ProviderConfig{}
+	_ Validator = SessionConfig{}
+	_ Validator = CookieConfig{}
+	_ Validator = TTLConfig{}
+	_ Validator = ClientConfig{}
+	_ Validator = ServerConfig{}
+	_ Validator = TimeoutConfig{}
+	_ Validator = MetricsConfig{}
+	_ Validator = StatsdConfig{}
+	_ Validator = LoggingConfig{}
+	_ Validator = UpstreamConfigs{}
+	_ Validator = DefaultConfig{}
+	_ Validator = EmailConfig{}
+	_ Validator = RequestSignerConfig{}
+)
+
+type Configuration struct {
+	ServerConfig        ServerConfig        `mapstructure:"server"`
+	ProviderConfig      ProviderConfig      `mapstructure:"provider"`
+	ClientConfig        ClientConfig        `mapstructure:"client"`
+	SessionConfig       SessionConfig       `mapstructure:"session"`
+	UpstreamConfigs     UpstreamConfigs     `mapstructure:"upstream"`
+	MetricsConfig       MetricsConfig       `mapstructure:"metrics"`
+	LoggingConfig       LoggingConfig       `mapstructure:"logging"`
+	RequestSignerConfig RequestSignerConfig `mapstructure:"requestsigner"`
+}
+
+func (c Configuration) Validate() error {
+	var validationErrors []string
+
+	if err := c.ServerConfig.Validate(); err != nil {
+		validationErrors = append(validationErrors, fmt.Sprintf("invalid server config: %s", err))
+	}
+
+	if err := c.ProviderConfig.Validate(); err != nil {
+		validationErrors = append(validationErrors, fmt.Sprintf("invalid provider config: %s", err))
+	}
+
+	if err := c.SessionConfig.Validate(); err != nil {
+		validationErrors = append(validationErrors, fmt.Sprintf("invalid session config: %s", err))
+	}
+
+	if err := c.ClientConfig.Validate(); err != nil {
+		validationErrors = append(validationErrors, fmt.Sprintf("invalid client config: %s", err))
+	}
+
+	if err := c.UpstreamConfigs.Validate(); err != nil {
+		validationErrors = append(validationErrors, fmt.Sprintf("invalid upstream config: %s", err))
+	}
+
+	if err := c.MetricsConfig.Validate(); err != nil {
+		validationErrors = append(validationErrors, fmt.Sprintf("invalid metrics config: %s", err))
+	}
+
+	if err := c.LoggingConfig.Validate(); err != nil {
+		validationErrors = append(validationErrors, fmt.Sprintf("invalid metrics config: %s", err))
+	}
+
+	if err := c.RequestSignerConfig.Validate(); err != nil {
+		validationErrors = append(validationErrors, fmt.Sprintf("invalid metrics config: %s", err))
+	}
+
+	if len(validationErrors) != 0 {
+		return fmt.Errorf(strings.Join(validationErrors, "\n"))
+	}
+
+	return nil
+}
+
+type ProviderConfig struct {
+	ProviderType      string            `mapstructure:"type"`
+	Scope             string            `mapstructure:"scope"`
+	ProviderURLConfig ProviderURLConfig `mapstructure:"url"`
+}
+
+func (pc ProviderConfig) Validate() error {
+	if err := pc.ProviderURLConfig.Validate(); err != nil {
+		return fmt.Errorf("invalid provider.providerurl config: %w", err)
+	}
+
+	if pc.ProviderType == "" {
+		return fmt.Errorf("no provider.type configured")
+	}
+
+	return nil
+}
+
+type ProviderURLConfig struct {
+	External string `mapstructure:"external"`
+	Internal string `mapstructure:"internal"`
+}
+
+func (puc ProviderURLConfig) Validate() error {
+	if puc.External == "" {
+		return errors.New("no providerurl.external configured")
+	} else {
+		providerURLExternal, err := url.Parse(puc.External)
+		if err != nil {
+			return err
+		}
+		if providerURLExternal.Scheme == "" || providerURLExternal.Host == "" {
+			return errors.New("providerurl.external must include scheme and host")
+		}
+	}
+
+	if puc.Internal != "" {
+		providerURLInternal, err := url.Parse(puc.Internal)
+		if err != nil {
+			return err
+		}
+		if providerURLInternal.Scheme == "" || providerURLInternal.Host == "" {
+			return errors.New("providerurl.internal must include scheme and host")
+		}
+	}
+	return nil
+}
+
+type SessionConfig struct {
+	CookieConfig CookieConfig `mapstructure:"cookie"`
+	TTLConfig    TTLConfig    `mapstructure:"ttl"`
+}
+
+func (sc SessionConfig) Validate() error {
+	if err := sc.CookieConfig.Validate(); err != nil {
+		return fmt.Errorf("invalid session.cookie config: %w", err)
+	}
+
+	if err := sc.TTLConfig.Validate(); err != nil {
+		return fmt.Errorf("invalid session.ttl config: %w", err)
+	}
+	return nil
+}
+
+type CookieConfig struct {
+	Name     string        `mapstructure:"name"`
+	Secret   string        `mapstructure:"secret"`
+	Expire   time.Duration `mapstructure:"expire"`
+	Domain   string        `mapstructure:"domain"`
+	Secure   bool          `mapstructure:"secure"`
+	HTTPOnly bool          `mapstructure:"httponly"`
+}
+
+func (cc CookieConfig) Validate() error {
+	if cc.Secret == "" {
+		return fmt.Errorf("no cookie.secret configured")
+	}
+	decodedCookieSecret, err := base64.StdEncoding.DecodeString(cc.Secret)
+	if err != nil {
+		return fmt.Errorf("invalid cookie.secret configured; expected base64-encoded bytes, as from `openssl rand 32 -base64`: %q", err)
+	}
+
+	validCookieSecretLength := false
+	for _, i := range []int{32, 64} {
+		if len(decodedCookieSecret) == i {
+			validCookieSecretLength = true
+		}
+	}
+	if !validCookieSecretLength {
+		return fmt.Errorf("invalid value for cookie.secret; must decode to 32 or 64 bytes, but decoded to %d bytes", len(decodedCookieSecret))
+	}
+
+	cookie := &http.Cookie{Name: cc.Name}
+	if cookie.String() == "" {
+		return fmt.Errorf("invalid cc.name: %q", cc.Name)
+	}
+	return nil
+}
+
+type TTLConfig struct {
+	Lifetime    time.Duration `mapstructure:"lifetime"`
+	Valid       time.Duration `mapstructure:"valid"`
+	GracePeriod time.Duration `mapstructre:"grace_period"`
+}
+
+func (ttlc TTLConfig) Validate() error {
+	return nil
+}
+
+type ClientConfig struct {
+	ID     string `mapstructure:"id"`
+	Secret string `mapstructure:"secret"`
+}
+
+func (cc ClientConfig) Validate() error {
+	if cc.ID == "" {
+		return fmt.Errorf("no client.id configured")
+	}
+	if cc.Secret == "" {
+		return fmt.Errorf("no client.secret configured")
+	}
+	return nil
+}
+
+type ServerConfig struct {
+	Port          int           `mapstructure:"port"`
+	TimeoutConfig TimeoutConfig `mapstructure:"timeout"`
+}
+
+func (sc ServerConfig) Validate() error {
+	if sc.Port == 0 {
+		return errors.New("no server.port configured")
+	}
+
+	if err := sc.TimeoutConfig.Validate(); err != nil {
+		return fmt.Errorf("invalid server.timeout config: %w", err)
+	}
+	return nil
+}
+
+type TimeoutConfig struct {
+	Write    time.Duration `mapstructure:"write"`
+	Read     time.Duration `mapstructure:"read"`
+	Shutdown time.Duration `mapstructure:"shutdown"`
+}
+
+func (tc TimeoutConfig) Validate() error {
+	return nil
+}
+
+type MetricsConfig struct {
+	StatsdConfig StatsdConfig `mapstructure:"statsd"`
+}
+
+func (mc MetricsConfig) Validate() error {
+	if err := mc.StatsdConfig.Validate(); err != nil {
+		return fmt.Errorf("invalid metrics.statsd config: %w", err)
+	}
+	return nil
+}
+
+type StatsdConfig struct {
+	Port int    `mapstructure:"port"`
+	Host string `mapstructure:"host"`
+}
+
+func (sc StatsdConfig) Validate() error {
+	if sc.Host == "" {
+		return errors.New("no statsd.host configured")
+	}
+
+	if sc.Port == 0 {
+		return errors.New("no statsd.port configured")
+	}
+	return nil
+}
+
+type LoggingConfig struct {
+	Enable bool `mapstructure:"enable"`
+}
+
+func (lc LoggingConfig) Validate() error {
+	return nil
+}
+
+type UpstreamConfigs struct {
+	DefaultConfig    DefaultConfig `mapstructure:"default"`
+	ConfigsFile      string        `mapstructure:"configfile"`
+	testTemplateVars map[string]string
+	upstreamConfigs  []*UpstreamConfig
+	Cluster          string `mapstructure:"cluster"`
+	Scheme           string `mapstructure:"scheme"`
+}
+
+func (uc UpstreamConfigs) Validate() error {
+	if err := uc.DefaultConfig.Validate(); err != nil {
+		return fmt.Errorf("invalid upstream.defaultconfig: %w", err)
+	}
+
+	if uc.ConfigsFile != "" {
+		r, err := os.Open(uc.ConfigsFile)
+		if err != nil {
+			return fmt.Errorf("invalid upstream.configfile: %w", err)
+		}
+		r.Close()
+	}
+
+	if uc.Cluster == "" {
+		return errors.New("no upstream.cluster configured")
+	}
+	return nil
+}
+
+type DefaultConfig struct {
+	EmailConfig   EmailConfig   `mapstructure:"email"`
+	AllowedGroups []string      `mapstructure:"groups"`
+	ProviderSlug  string        `mapstructure:"provider"`
+	Timeout       time.Duration `mapstructure:"timeout"`
+	ResetDeadline time.Duration `mapstructure:"resetdeadline"`
+}
+
+func (dc DefaultConfig) Validate() error {
+	if err := dc.EmailConfig.Validate(); err != nil {
+		return fmt.Errorf("invalid default.emailconfig: %w", err)
+	}
+
+	if dc.ProviderSlug == "" {
+		return fmt.Errorf("no defaultconfig.provider configured")
+	}
+
+	return nil
+	//TODO tests here - timeout and reset deadline?
+}
+
+type EmailConfig struct {
+	AllowedDomains   []string `mapstructure:"domains"`
+	AllowedAddresses []string `mapstructure:"addresses"`
+}
+
+func (ec EmailConfig) Validate() error {
+	return nil
+}
+
+type RequestSignerConfig struct {
+	Key string `mapstructure:"key"`
+}
+
+func (rsc RequestSignerConfig) Validate() error {
+	return nil
+}
+
+// LoadConfig loads all the configuration from env and defaults
+func LoadConfig() (Configuration, error) {
+	c := DefaultProxyConfig()
+
+	conf := config.NewConfig()
+	err := conf.Load(env.NewSource())
+	if err != nil {
+		return c, err
+	}
+
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		DecodeHook: mapstructure.ComposeDecodeHookFunc(
+			mapstructure.StringToTimeDurationHookFunc(),
+			mapstructure.StringToSliceHookFunc(","),
+		),
+		Result: &c,
+	})
+	if err != nil {
+		return c, err
+	}
+
+	err = decoder.Decode(conf.Map())
+	if err != nil {
+		return c, err
+	}
+
+	return c, nil
+}

--- a/internal/proxy/configuration_test.go
+++ b/internal/proxy/configuration_test.go
@@ -1,0 +1,409 @@
+package proxy
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func assertEq(want, have interface{}, t *testing.T) {
+	if !reflect.DeepEqual(want, have) {
+		t.Errorf("want: %#v", want)
+		t.Errorf("have: %#v", have)
+		t.Errorf("expected values to be equal")
+	}
+}
+
+func TestDefaultConfiguration(t *testing.T) {
+	// First, check that LoadConfig() returns the expected default config.
+	default_config := DefaultProxyConfig()
+	loaded_config, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("unexpected err loading config: %v", err)
+	}
+	assertEq(default_config, loaded_config, t)
+
+	// Then, check that DefaultProxyConfig() returns a valid config. A small number of configuration settings
+	// are *not* supplied by DefaultProxyConfig(), but *are* required. We add those in below for the sake of testing.
+	default_config.ProviderConfig.ProviderURLConfig.External = "https://provider.example.com"
+	default_config.SessionConfig.CookieConfig.Secret = "4HG6i5p+/D0e4NrC8AmLeCZ6mGgaYfy8wxgBmAvNWmM="
+	default_config.ClientConfig.ID = "foo_id"
+	default_config.ClientConfig.Secret = "foo_secret"
+	default_config.UpstreamConfigs.Cluster = "foo_cluster"
+
+	err = default_config.Validate()
+	if err != nil {
+		t.Fatalf("unexpected err validating default config: %v", err)
+	}
+}
+
+func TestConfigCatchAllValidateErrors(t *testing.T) {
+	config := Configuration{}
+	err := config.Validate()
+	expected := []string{
+		"invalid server config: no server.port configured",
+		"invalid provider config: invalid provider.providerurl config: no providerurl.external configured",
+		"invalid session config: invalid session.cookie config: no cookie.secret configured",
+		"invalid client config: no client.id configured",
+		"invalid upstream config: invalid upstream.defaultconfig: no defaultconfig.provider configured",
+		"invalid metrics config: invalid metrics.statsd config: no statsd.host configured",
+	}
+	assertEq(expected, strings.Split(err.Error(), "\n"), t)
+}
+
+func TestEnvironmentOverridesConfiguration(t *testing.T) {
+	testCases := []struct {
+		Name         string
+		EnvOverrides map[string]string
+		CheckFunc    func(c Configuration, t *testing.T)
+	}{
+		{
+			Name: "Test Session Cookie Config Name Overrides",
+			EnvOverrides: map[string]string{
+				"SESSION_COOKIE_NAME": "foo_cookie_name",
+			},
+			CheckFunc: func(c Configuration, t *testing.T) {
+				assertEq("foo_cookie_name", c.SessionConfig.CookieConfig.Name, t)
+			},
+		},
+		{
+			Name: "Test Request Timeout Overrides",
+			EnvOverrides: map[string]string{
+				"SERVER_TIMEOUT_WRITE": "60s",
+				"SERVER_TIMEOUT_READ":  "60s",
+			},
+			CheckFunc: func(c Configuration, t *testing.T) {
+				assertEq(60*time.Second, c.ServerConfig.TimeoutConfig.Write, t)
+				assertEq(60*time.Second, c.ServerConfig.TimeoutConfig.Read, t)
+			},
+		},
+		{
+			Name: "Test Provider Config Overrides",
+			EnvOverrides: map[string]string{
+				"UPSTREAM_DEFAULT_PROVIDER": "foo-slug",
+			},
+			CheckFunc: func(c Configuration, t *testing.T) {
+				assertEq("foo-slug", c.UpstreamConfigs.DefaultConfig.ProviderSlug, t)
+			},
+		},
+		//{
+		//	Name: "some upstream config tests?",
+		//},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			os.Clearenv()
+			for k, v := range tc.EnvOverrides {
+				err := os.Setenv(k, v)
+				if err != nil {
+					t.Fatalf("unexpected err setting env: %v", err)
+				}
+			}
+			have, err := LoadConfig()
+			if err != nil {
+				t.Fatalf("unexpected err loading config: %v", err)
+			}
+			tc.CheckFunc(have, t)
+		})
+	}
+}
+
+func TestConfigValidate(t *testing.T) {
+	testCases := []struct {
+		Name        string
+		Validator   Validator
+		ExpectedErr error
+	}{
+		{
+			Name: "config validation should pass",
+			Validator: Configuration{
+				ServerConfig: ServerConfig{
+					Port: 4180,
+					TimeoutConfig: TimeoutConfig{
+						Write:    30 * time.Second,
+						Read:     30 * time.Second,
+						Shutdown: 30 * time.Second,
+					},
+				},
+				ProviderConfig: ProviderConfig{
+					ProviderType: "sso",
+					Scope:        "test",
+					ProviderURLConfig: ProviderURLConfig{
+						External: "https://sso-external.com",
+						Internal: "https://sso-internal.com",
+					},
+				},
+				ClientConfig: ClientConfig{
+					ID:     "foo-id",
+					Secret: "bar-secret",
+				},
+				SessionConfig: SessionConfig{
+					CookieConfig: CookieConfig{
+						Name:     "_sso_proxy",
+						Expire:   168 * time.Hour,
+						Secure:   true,
+						Secret:   "SMoPfinxNz0fuaGFPUr5vwQpvoG+CGcLd2nkxRVI+H4=",
+						HTTPOnly: true,
+					},
+					TTLConfig: TTLConfig{
+						Lifetime:    720 * time.Hour,
+						Valid:       60 * time.Second,
+						GracePeriod: 3 * time.Hour,
+					},
+				},
+				UpstreamConfigs: UpstreamConfigs{
+					DefaultConfig: DefaultConfig{
+						Timeout:       10 * time.Second,
+						ResetDeadline: 60 * time.Second,
+						ProviderSlug:  "google",
+					},
+					Scheme:  "https",
+					Cluster: "foo-cluster",
+				},
+				LoggingConfig: LoggingConfig{
+					Enable: true,
+				},
+				MetricsConfig: MetricsConfig{
+					StatsdConfig: StatsdConfig{
+						Port: 8125,
+						Host: "localhost",
+					},
+				},
+			},
+		},
+		// Server Validate() tests
+		{
+			Name: "ServerConfig: missing server.port configuration",
+			Validator: ServerConfig{
+				TimeoutConfig: TimeoutConfig{
+					Write:    30 * time.Second,
+					Read:     30 * time.Second,
+					Shutdown: 30 * time.Second,
+				},
+			},
+			ExpectedErr: errors.New("no server.port configured"),
+		},
+		// SessionConfig.CookieConfig Validate() tests
+		{
+			Name: "CookieConfig: invalid cookie.secret",
+			Validator: SessionConfig{
+				CookieConfig: CookieConfig{
+					Secret: "invalid_string_format",
+				},
+			},
+			ExpectedErr: errors.New(
+				"invalid session.cookie config: invalid cookie.secret configured; expected base64-encoded bytes, as from `openssl rand 32 -base64`: \"illegal base64 data at input byte 7\""),
+		},
+		{
+			Name: "CookieConfig: invalid cookie.secret value",
+			Validator: SessionConfig{
+				CookieConfig: CookieConfig{
+					// created with `openssl rand 30 -base64`
+					Secret: "NXKCLbT+jXZD9Ep5xDo2EsM82F/kv3KZT2vJ7XvV",
+				},
+			},
+			ExpectedErr: errors.New(
+				"invalid session.cookie config: invalid value for cookie.secret; must decode to 32 or 64 bytes, but decoded to 30 bytes"),
+		},
+		{
+			Name: "CookieConfig: missing cookie.name",
+			Validator: SessionConfig{
+				CookieConfig: CookieConfig{
+					// created with `openssl rand 32 -base64`
+					Secret: "ekVGRbawiXuvVhgyKUIg0KQXw0ubdSd3rE9Pheog1JU=",
+					Name:   "",
+				},
+			},
+			ExpectedErr: errors.New(
+				"invalid session.cookie config: invalid cc.name: \"\""),
+		},
+		// ClientConfig Validate() tests
+		{
+			Name: "ClientConfig: missing client.id",
+			Validator: ClientConfig{
+				ID: "",
+			},
+			ExpectedErr: errors.New(
+				"no client.id configured"),
+		},
+		{
+			Name: "ClientConfig: missing client.secret",
+			Validator: ClientConfig{
+				ID:     "foo_id",
+				Secret: "",
+			},
+			ExpectedErr: errors.New(
+				"no client.secret configured"),
+		},
+		// MetricsConfig Validate() tests
+		{
+			Name: "MetricsConfig: missing metrics.statsd.host",
+			Validator: MetricsConfig{
+				StatsdConfig: StatsdConfig{
+					Host: "",
+				},
+			},
+			ExpectedErr: errors.New(
+				"invalid metrics.statsd config: no statsd.host configured"),
+		},
+		{
+			Name: "MetricsConfig: missing metrics.statsd.port",
+			Validator: MetricsConfig{
+				StatsdConfig: StatsdConfig{
+					Host: "foo_host",
+					Port: 0,
+				},
+			},
+			ExpectedErr: errors.New(
+				"invalid metrics.statsd config: no statsd.port configured"),
+		},
+		// ProviderConfig Validate() tests
+		{
+			Name: "ProviderConfig: missing provider.type",
+			Validator: ProviderConfig{
+				ProviderType: "",
+				ProviderURLConfig: ProviderURLConfig{
+					Internal: "",
+					External: "https://foo.bar.com",
+				},
+			},
+			ExpectedErr: errors.New(
+				"no provider.type configured"),
+		},
+		{
+			Name: "ProviderConfig: missing provider.providerurl.external",
+			Validator: ProviderConfig{
+				ProviderType: "foo",
+				ProviderURLConfig: ProviderURLConfig{
+					Internal: "",
+					External: "",
+				},
+			},
+			ExpectedErr: errors.New(
+				"invalid provider.providerurl config: no providerurl.external configured"),
+		},
+		{
+			Name: "ProviderConfig: invalid provider.providerurl.external format",
+			Validator: ProviderConfig{
+				ProviderType: "foo",
+				ProviderURLConfig: ProviderURLConfig{
+					Internal: "",
+					External: "/simply/a/URL/path",
+				},
+			},
+			ExpectedErr: errors.New(
+				"invalid provider.providerurl config: providerurl.external must include scheme and host"),
+		},
+		{
+			Name: "ProviderConfig: provider.providerurl.internal missing scheme or host",
+			Validator: ProviderConfig{
+				ProviderType: "foo",
+				ProviderURLConfig: ProviderURLConfig{
+					Internal: "/simply/a/URL/path",
+					External: "https://foo.bar.com",
+				},
+			},
+			ExpectedErr: errors.New(
+				"invalid provider.providerurl config: providerurl.internal must include scheme and host"),
+		},
+		{
+			Name: "ProviderConfig: invalid provider.providerurl.internal format",
+			Validator: ProviderConfig{
+				ProviderType: "foo",
+				ProviderURLConfig: ProviderURLConfig{
+					Internal: "%ZZZ",
+					External: "https://foo.bar.com",
+				},
+			},
+			ExpectedErr: errors.New(
+				"invalid provider.providerurl config: parse \"%ZZZ\": invalid URL escape \"%ZZ\""),
+		},
+		// UpstreamConfigs Validate() tests
+		{
+			Name: "UpstreamConfisg: missing upstreamconfig.defaultconfig.provider",
+			Validator: UpstreamConfigs{
+				DefaultConfig: DefaultConfig{
+					ProviderSlug: "",
+				},
+				Cluster: "foo_cluster",
+			},
+			ExpectedErr: errors.New(
+				"invalid upstream.defaultconfig: no defaultconfig.provider configured"),
+		},
+		{
+			Name: "UpstreamConfigs: missing upstreamconfig.cluster",
+			Validator: UpstreamConfigs{
+				DefaultConfig: DefaultConfig{
+					ProviderSlug: "foo_provider",
+				},
+				Cluster: "",
+			},
+			ExpectedErr: errors.New(
+				"no upstream.cluster configured"),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			err := tc.Validator.Validate()
+			if err != nil && tc.ExpectedErr != nil {
+				assertEq(tc.ExpectedErr.Error(), err.Error(), t)
+			} else {
+				assertEq(tc.ExpectedErr, err, t)
+			}
+		})
+	}
+}
+
+func TestUpstreamConfigs(t *testing.T) {
+	testCases := []struct {
+		Name           string
+		CreateTempFile bool
+		UpstreamConfig UpstreamConfigs
+		ExpectedErr    error
+	}{
+		{
+			Name: "valid upstreamconfig",
+			UpstreamConfig: UpstreamConfigs{
+				Cluster: "foo_cluster",
+				DefaultConfig: DefaultConfig{
+					ProviderSlug: "foo_provider",
+				},
+			},
+			CreateTempFile: true,
+		},
+		{
+			Name: "invalid filepath given",
+			UpstreamConfig: UpstreamConfigs{
+				ConfigsFile: "foo_invalid_file_path",
+				Cluster:     "foo_cluster",
+				DefaultConfig: DefaultConfig{
+					ProviderSlug: "foo_provider",
+				},
+			},
+			ExpectedErr: errors.New(
+				"invalid upstream.configfile: open foo_invalid_file_path: no such file or directory"),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+
+			tempFilePath := ""
+			if tc.CreateTempFile {
+				tmpFile, _ := ioutil.TempFile("", "")
+				tempFilePath = tmpFile.Name()
+				tc.UpstreamConfig.ConfigsFile = tempFilePath
+			}
+
+			err := tc.UpstreamConfig.Validate()
+			if err != nil && tc.ExpectedErr != nil {
+				assertEq(tc.ExpectedErr.Error(), err.Error(), t)
+			} else {
+				assertEq(tc.ExpectedErr, err, t)
+			}
+		})
+	}
+}

--- a/internal/proxy/logging_handler.go
+++ b/internal/proxy/logging_handler.go
@@ -88,10 +88,10 @@ type loggingHandler struct {
 }
 
 // NewLoggingHandler returns a new loggingHandler that wraps a handler, statsd client, and writer.
-func NewLoggingHandler(out io.Writer, h http.Handler, v bool, StatsdClient *statsd.Client) http.Handler {
+func NewLoggingHandler(out io.Writer, h http.Handler, lc LoggingConfig, StatsdClient *statsd.Client) http.Handler {
 	return loggingHandler{writer: out,
 		handler:      h,
-		enabled:      v,
+		enabled:      lc.Enable,
 		StatsdClient: StatsdClient,
 	}
 }

--- a/internal/proxy/metrics.go
+++ b/internal/proxy/metrics.go
@@ -11,8 +11,8 @@ import (
 )
 
 // newStatsdClient creates and returns a statsd client on a host and port that is namespaced to 'sso_proxy'
-func newStatsdClient(opts *Options) (*statsd.Client, error) {
-	client, err := statsd.New(net.JoinHostPort(opts.StatsdHost, strconv.Itoa(opts.StatsdPort)))
+func NewStatsdClient(host string, port int) (*statsd.Client, error) {
+	client, err := statsd.New(net.JoinHostPort(host, strconv.Itoa(port)))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/proxy/metrics_test.go
+++ b/internal/proxy/metrics_test.go
@@ -53,15 +53,8 @@ func TestNewStatsd(t *testing.T) {
 				t.Fatalf("error %s", err.Error())
 			}
 			defer pc.Close()
-			opts := NewOptions()
-			opts.StatsdHost = tc.host
-			opts.StatsdPort = tc.port
-			opts.Validate()
-			if err != nil {
-				t.Fatalf("error while instantiating config options: %v", err.Error())
-			}
 
-			client, err := newStatsdClient(opts)
+			client, err := NewStatsdClient(tc.host, tc.port)
 			if err != nil {
 				t.Fatalf("error starting new statsd client: %s", err.Error())
 			}
@@ -154,15 +147,7 @@ func TestLogRequestMetrics(t *testing.T) {
 			}
 			defer pc.Close()
 
-			opts := NewOptions()
-			opts.StatsdHost = "127.0.0.1"
-			opts.StatsdPort = 8125
-			opts.Validate()
-			if err != nil {
-				t.Fatalf("error while instantiating config options: %v", err.Error())
-			}
-
-			client, err := newStatsdClient(opts)
+			client, err := NewStatsdClient("127.0.0.1", 8125)
 			if err != nil {
 				t.Fatalf("error starting new statsd client: %s", err.Error())
 			}

--- a/internal/proxy/options.go
+++ b/internal/proxy/options.go
@@ -2,311 +2,202 @@ package proxy
 
 import (
 	"encoding/base64"
-	"errors"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
 	"strings"
-	"time"
 
+	log "github.com/buzzfeed/sso/internal/pkg/logging"
+	"github.com/buzzfeed/sso/internal/pkg/options"
+	"github.com/buzzfeed/sso/internal/pkg/sessions"
 	"github.com/buzzfeed/sso/internal/proxy/providers"
 
 	"github.com/datadog/datadog-go/statsd"
 )
 
-// Options are configuration options that can be set by Environment Variables
-// Port - int -  port to listen on for HTTP clients
-// ProviderURLString - the URL for the provider in this environment: "https://sso-auth.example.com"
-// ProxyProviderURLString - the internal URL for the provider in this environment: "https://sso-auth-int.example.com"
-// UpstreamConfigsFile - the path to upstream configs file
-// Cluster - the cluster in which this is running, used for upstream configs
-// Scheme - the default scheme, used for upstream configs
-// SkipAuthPreflight - will skip authentication for OPTIONS requests, default false
-// DefaultAllowedEmailDomains - csv list of emails with the specified domain to authenticate. Use * to authenticate any email
-// DefaultAllowedEmailAddresses - []string - authenticate emails with the specified email address (may be given multiple times). Use * to authenticate any email
-// DefaultAllowedGroups - csv list of default allowed groups that are applied to authorize access to upstreams. Will be overridden by groups specified in upstream configs.
-// DefaultProviderSlug - the provider that upstreams should use by default. Provider must exist within `sso_auth`. ie: "google"
-// ClientID - the OAuth Client ID: ie: "123456.apps.googleusercontent.com"
-// ClientSecret - The OAuth Client Secret
-// DefaultUpstreamTimeout - the default time period to wait for a response from an upstream
-// DefaultUpstreamTCPResetDeadline - the default time period to wait for a response from an upstream
-// TCPWriteTimeout - http server tcp write timeout - set to: max(default value specified, max(upstream timeouts))
-// TCPReadTimeout - http server tcp read timeout
-// CookieName - name of the cookie
-// CookieSecret - the seed string for secure cookies (optionally base64 encoded)
-// CookieDomain - an optional cookie domain to force cookies to (ie: .yourcompany.com)*
-// CookieExpire - expire timeframe for cookie
-// CookieSecure - set secure (HTTPS) cookie flag
-// CookieHTTPOnly - set HttpOnly cookie flag
-// PassAccessToken - send access token in the http headers
-// Provider - OAuth provider
-// DefaultProviderSlug - OAuth provider slug, used internally to identity a specific provider
-// Scope - OAuth scope specification
-// SessionLifetimeTTL - time to live for a session lifetime
-// SessionValidTTL - time to live for a valid session
-// GracePeriodTTL - time to reuse session data when provider unavailable
-// RequestLoging - boolean whether or not to log requests
-// StatsdHost - host addr for statsd client to listen on
-// StatsdPort - port for statsdclient to listen on
-// ShutdownTimeout - maximum time to wait for in-flight HTTP requests to complete before shutdown
-type Options struct {
-	Port int `envconfig:"PORT" default:"4180"`
+// SetCookieStore sets the session and csrf stores as a functional option
+func SetCookieStore(cc CookieConfig) func(*OAuthProxy) error {
+	return func(op *OAuthProxy) error {
 
-	ProviderURLString         string `envconfig:"PROVIDER_URL"`
-	ProviderURLInternalString string `envconfig:"PROVIDER_URL_INTERNAL"`
-	UpstreamConfigsFile       string `envconfig:"UPSTREAM_CONFIGS"`
-	Cluster                   string `envconfig:"CLUSTER"`
-	Scheme                    string `envconfig:"SCHEME" default:"https"`
-
-	SkipAuthPreflight bool `envconfig:"SKIP_AUTH_PREFLIGHT"`
-
-	DefaultAllowedEmailDomains   []string `envconfig:"DEFAULT_ALLOWED_EMAIL_DOMAINS"`
-	DefaultAllowedEmailAddresses []string `envconfig:"DEFAULT_ALLOWED_EMAIL_ADDRESSES"`
-	DefaultAllowedGroups         []string `envconfig:"DEFAULT_ALLOWED_GROUPS"`
-
-	ClientID     string `envconfig:"CLIENT_ID"`
-	ClientSecret string `envconfig:"CLIENT_SECRET"`
-
-	DefaultUpstreamTimeout          time.Duration `envconfig:"DEFAULT_UPSTREAM_TIMEOUT" default:"10s"`
-	DefaultUpstreamTCPResetDeadline time.Duration `envconfig:"DEFAULT_UPSTREAM_TCP_RESET_DEADLINE" default:"60s"`
-
-	TCPWriteTimeout time.Duration `envconfig:"TCP_WRITE_TIMEOUT" default:"30s"`
-	TCPReadTimeout  time.Duration `envconfig:"TCP_READ_TIMEOUT" default:"30s"`
-
-	CookieName     string        `envconfig:"COOKIE_NAME" default:"_sso_proxy"`
-	CookieSecret   string        `envconfig:"COOKIE_SECRET"`
-	CookieDomain   string        `envconfig:"COOKIE_DOMAIN"`
-	CookieExpire   time.Duration `envconfig:"COOKIE_EXPIRE" default:"168h"`
-	CookieSecure   bool          `envconfig:"COOKIE_SECURE" default:"true"`
-	CookieHTTPOnly bool          `envconfig:"COOKIE_HTTP_ONLY"`
-
-	PassAccessToken bool `envconfig:"PASS_ACCESS_TOKEN" default:"false"`
-
-	Provider            string `envconfig:"PROVIDER" default:"sso"`
-	DefaultProviderSlug string `envconfig:"DEFAULT_PROVIDER_SLUG" default:"google"`
-	Scope               string `envconfig:"SCOPE"`
-
-	SessionLifetimeTTL time.Duration `envconfig:"SESSION_LIFETIME_TTL" default:"720h"`
-	SessionValidTTL    time.Duration `envconfig:"SESSION_VALID_TTL" default:"1m"`
-	GracePeriodTTL     time.Duration `envconfig:"GRACE_PERIOD_TTL" default:"3h"`
-
-	RequestLogging bool `envconfig:"REQUEST_LOGGING" default:"true"`
-
-	StatsdHost string `envconfig:"STATSD_HOST"`
-	StatsdPort int    `envconfig:"STATSD_PORT"`
-
-	RequestSigningKey string `envconfig:"REQUEST_SIGNATURE_KEY"`
-
-	ShutdownTimeout time.Duration `envconfig:"SHUTDOWN_TIMEOUT" default:"30s"`
-
-	StatsdClient *statsd.Client
-
-	// This is an override for supplying template vars at test time
-	testTemplateVars map[string]string
-
-	// internal values that are set after config validation
-	upstreamConfigs     []*UpstreamConfig
-	decodedCookieSecret []byte
-}
-
-// NewOptions returns a new options struct
-func NewOptions() *Options {
-	return &Options{
-		CookieName:     "_sso_proxy",
-		CookieSecure:   true,
-		CookieHTTPOnly: true,
-		CookieExpire:   time.Duration(168) * time.Hour,
-
-		SkipAuthPreflight: false,
-		RequestLogging:    true,
-
-		DefaultUpstreamTimeout:          time.Duration(1) * time.Second,
-		DefaultUpstreamTCPResetDeadline: time.Duration(1) * time.Minute,
-
-		DefaultAllowedEmailAddresses: []string{},
-		DefaultAllowedEmailDomains:   []string{},
-		DefaultAllowedGroups:         []string{},
-		PassAccessToken:              false,
-	}
-}
-
-// Validate validates options
-func (o *Options) Validate() error {
-	msgs := make([]string, 0)
-	if o.Cluster == "" {
-		msgs = append(msgs, "missing setting: cluster")
-	}
-	if o.ProviderURLString == "" {
-		msgs = append(msgs, "missing setting: provider-url")
-	}
-	if o.UpstreamConfigsFile == "" {
-		msgs = append(msgs, "missing setting: upstream-configs")
-	}
-	if o.CookieSecret == "" {
-		msgs = append(msgs, "missing setting: cookie-secret")
-	}
-	if o.ClientID == "" {
-		msgs = append(msgs, "missing setting: client-id")
-	}
-	if o.ClientSecret == "" {
-		msgs = append(msgs, "missing setting: client-secret")
-	}
-
-	if o.StatsdHost == "" {
-		msgs = append(msgs, "missing setting: statsd-host")
-	}
-
-	if o.StatsdPort == 0 {
-		msgs = append(msgs, "missing setting: statsd-port")
-	}
-	if o.StatsdHost != "" && o.StatsdPort != 0 {
-		StatsdClient, err := newStatsdClient(o)
-		if err != nil {
-			msgs = append(msgs, fmt.Sprintf("error creating statsd client error=%q", err))
-		}
-		o.StatsdClient = StatsdClient
-	}
-
-	if o.UpstreamConfigsFile != "" {
-		rawBytes, err := ioutil.ReadFile(o.UpstreamConfigsFile)
-		if err != nil {
-			msgs = append(msgs, fmt.Sprintf("error reading upstream configs file: %s", err))
-		}
-
-		templateVars := parseEnvironment(os.Environ())
-		if o.testTemplateVars != nil {
-			templateVars = o.testTemplateVars
-		}
-
-		defaultUpstreamOptionsConfig := &OptionsConfig{
-			AllowedEmailAddresses: o.DefaultAllowedEmailAddresses,
-			AllowedEmailDomains:   o.DefaultAllowedEmailDomains,
-			AllowedGroups:         o.DefaultAllowedGroups,
-			Timeout:               o.DefaultUpstreamTimeout,
-			ResetDeadline:         o.DefaultUpstreamTCPResetDeadline,
-			ProviderSlug:          o.DefaultProviderSlug,
-			CookieName:            o.CookieName,
-		}
-
-		o.upstreamConfigs, err = loadServiceConfigs(rawBytes, o.Cluster, o.Scheme, templateVars, defaultUpstreamOptionsConfig)
-		if err != nil {
-			msgs = append(msgs, fmt.Sprintf("error parsing upstream configs file %s", err))
-		}
-	}
-
-	if o.upstreamConfigs != nil {
-		invalidUpstreams := []string{}
-		for _, uc := range o.upstreamConfigs {
-			if uc.Timeout > o.TCPWriteTimeout {
-				o.TCPWriteTimeout = uc.Timeout
-			}
-
-			if len(uc.AllowedEmailDomains) == 0 && len(uc.AllowedEmailAddresses) == 0 && len(uc.AllowedGroups) == 0 {
-				invalidUpstreams = append(invalidUpstreams, uc.Service)
-			}
-		}
-		if len(invalidUpstreams) != 0 {
-			msgs = append(msgs, fmt.Sprintf(
-				"missing setting: ALLOWED_EMAIL_DOMAINS, ALLOWED_EMAIL_ADDRESSES, ALLOWED_GROUPS default in environment or override in upstream config in the following upstreams: %v",
-				invalidUpstreams))
-		}
-	}
-
-	if o.ProviderURLString != "" {
-		err := parseProviderInfo(o)
-		if err != nil {
-			msgs = append(msgs, fmt.Sprintf("invalid value for provider-url: %s", err.Error()))
-		}
-	}
-
-	decodedCookieSecret, err := base64.StdEncoding.DecodeString(o.CookieSecret)
-	if err != nil {
-		msgs = append(msgs, "Invalid value for COOKIE_SECRET; expected base64-encoded bytes, as from `openssl rand 32 -base64`")
-	}
-	validCookieSecretLength := false
-	for _, i := range []int{32, 64} {
-		if len(decodedCookieSecret) == i {
-			validCookieSecretLength = true
-		}
-	}
-
-	if !validCookieSecretLength {
-		msgs = append(msgs, fmt.Sprintf("Invalid value for COOKIE_SECRET; must decode to 32 or 64 bytes, but decoded to %d bytes", len(decodedCookieSecret)))
-	}
-
-	o.decodedCookieSecret = decodedCookieSecret
-
-	msgs = validateCookieName(o, msgs)
-
-	if len(msgs) != 0 {
-		return fmt.Errorf("Invalid configuration:\n  %s",
-			strings.Join(msgs, "\n  "))
-	}
-	return nil
-}
-
-func parseProviderInfo(o *Options) error {
-	providerURL, err := url.Parse(o.ProviderURLString)
-	if err != nil {
-		return err
-	}
-
-	if providerURL.Scheme == "" || providerURL.Host == "" {
-		return errors.New("provider-url must include scheme and host")
-	}
-
-	var providerURLInternal *url.URL
-	if o.ProviderURLInternalString != "" {
-		providerURLInternal, err = url.Parse(o.ProviderURLInternalString)
+		decodedCookieSecret, err := base64.StdEncoding.DecodeString(cc.Secret)
 		if err != nil {
 			return err
 		}
-		if providerURLInternal.Scheme == "" || providerURLInternal.Host == "" {
-			return errors.New("proxy provider url must include scheme and host")
+
+		cookieStore, err := sessions.NewCookieStore(cc.Name,
+			sessions.CreateMiscreantCookieCipher(decodedCookieSecret),
+			func(c *sessions.CookieStore) error {
+				c.CookieDomain = cc.Domain
+				c.CookieHTTPOnly = cc.HTTPOnly
+				c.CookieExpire = cc.Expire
+				c.CookieSecure = cc.Secure
+				return nil
+			})
+
+		if err != nil {
+			return err
+		}
+
+		op.csrfStore = cookieStore
+		op.sessionStore = cookieStore
+		op.cookieCipher = cookieStore.CookieCipher
+		return nil
+	}
+}
+
+// SetRequestSigner sets the request signer  as a functional option
+func SetRequestSigner(signer *RequestSigner) func(*OAuthProxy) error {
+	logger := log.NewLogEntry()
+	return func(op *OAuthProxy) error {
+		if signer == nil {
+			logger.Warn("Running OAuthProxy without signing key. Requests will not be signed.")
+			return nil
+		}
+
+		// Configure the RequestSigner (used to sign requests with `Sso-Signature` header).
+		// Also build the `certs` static JSON-string which will be served from a public endpoint.
+		// The key published at this endpoint allows upstreams to decrypt the `Sso-Signature`
+		// header, and validate the integrity and authenticity of a request.
+
+		certs := make(map[string]string)
+		id, key := signer.PublicKey()
+		certs[id] = key
+
+		certsAsStr, err := json.MarshalIndent(certs, "", "  ")
+		if err != nil {
+			return fmt.Errorf("could not marshal public certs as JSON: %s", err)
+		}
+
+		op.requestSigner = signer
+		op.publicCertsJSON = certsAsStr
+
+		return nil
+	}
+}
+
+// SetUpstreamConfig sets the upstream config as a functional option
+func SetUpstreamConfig(upstreamConfig *UpstreamConfig) func(*OAuthProxy) error {
+	return func(op *OAuthProxy) error {
+		op.upstreamConfig = upstreamConfig
+		return nil
+	}
+}
+
+// SetProxyHandler sets the proxy handler as a functional option
+func SetProxyHandler(handler http.Handler) func(*OAuthProxy) error {
+	return func(op *OAuthProxy) error {
+		op.handler = handler
+		return nil
+	}
+}
+
+// SetValidator sets the email validator as a functional option
+func SetValidators(validators []options.Validator) func(*OAuthProxy) error {
+	return func(op *OAuthProxy) error {
+		op.Validators = validators
+		return nil
+	}
+}
+
+// SetProvider sets the provider as a functional option
+func SetProvider(provider providers.Provider) func(*OAuthProxy) error {
+	return func(op *OAuthProxy) error {
+		op.provider = provider
+		return nil
+	}
+}
+
+func SetUpstreamConfigs(uc *UpstreamConfigs, cc CookieConfig, svc *ServerConfig) error {
+	if uc.ConfigsFile != "" {
+		rawBytes, err := ioutil.ReadFile(uc.ConfigsFile)
+		if err != nil {
+			return fmt.Errorf("error reading upstream configs file: %s", err)
+		}
+
+		templateVars := parseEnvironment(os.Environ())
+		if uc.testTemplateVars != nil {
+			templateVars = uc.testTemplateVars
+		}
+
+		defaultUpstreamOptionsConfig := &OptionsConfig{
+			AllowedEmailAddresses: uc.DefaultConfig.EmailConfig.AllowedAddresses,
+			AllowedEmailDomains:   uc.DefaultConfig.EmailConfig.AllowedDomains,
+			AllowedGroups:         uc.DefaultConfig.AllowedGroups,
+			Timeout:               uc.DefaultConfig.Timeout,
+			ResetDeadline:         uc.DefaultConfig.ResetDeadline,
+			ProviderSlug:          uc.DefaultConfig.ProviderSlug,
+			CookieName:            cc.Name,
+		}
+
+		uc.upstreamConfigs, err = loadServiceConfigs(rawBytes, uc.Cluster, uc.Scheme, templateVars, defaultUpstreamOptionsConfig)
+		if err != nil {
+			return fmt.Errorf("error parsing upstream configs file %s", err)
+		}
+	}
+
+	if uc.upstreamConfigs != nil {
+		invalidUpstreams := []string{}
+		for _, c := range uc.upstreamConfigs {
+			if c.Timeout > svc.TimeoutConfig.Write {
+				svc.TimeoutConfig.Write = c.Timeout
+			}
+
+			if len(c.AllowedEmailDomains) == 0 && len(c.AllowedEmailAddresses) == 0 && len(c.AllowedGroups) == 0 {
+				invalidUpstreams = append(invalidUpstreams, c.Service)
+			}
+		}
+		if len(invalidUpstreams) != 0 {
+			return fmt.Errorf(
+				"missing setting: ALLOWED_EMAIL_DOMAINS, ALLOWED_EMAIL_ADDRESSES, ALLOWED_GROUPS default in environment or override in upstream config in the following upstreams: %v",
+				invalidUpstreams)
 		}
 	}
 
 	return nil
 }
 
-func newProvider(opts *Options, upstreamConfig *UpstreamConfig) (providers.Provider, error) {
-	providerURL, err := url.Parse(opts.ProviderURLString)
+func newProvider(cc ClientConfig, pc ProviderConfig, sc SessionConfig, uc UpstreamConfigs, statsdClient *statsd.Client) (providers.Provider, error) {
+	providerURL, err := url.Parse(pc.ProviderURLConfig.External)
 	if err != nil {
 		return nil, err
 	}
 
 	var providerURLInternal *url.URL
-	if opts.ProviderURLInternalString != "" {
-		providerURLInternal, err = url.Parse(opts.ProviderURLInternalString)
+	if pc.ProviderURLConfig.Internal != "" {
+		//TODO: sort out this providerURLInternal/External stuff
+		providerURLInternal, err = url.Parse(pc.ProviderURLConfig.Internal)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	providerData := &providers.ProviderData{
-		ClientID:            opts.ClientID,
-		ClientSecret:        opts.ClientSecret,
+		ClientID:     cc.ID,
+		ClientSecret: cc.Secret,
+
 		ProviderURL:         providerURL,
 		ProviderURLInternal: providerURLInternal,
-		ProviderSlug:        upstreamConfig.ProviderSlug,
-		Scope:               opts.Scope,
-		SessionLifetimeTTL:  opts.SessionLifetimeTTL,
-		SessionValidTTL:     opts.SessionValidTTL,
-		GracePeriodTTL:      opts.GracePeriodTTL,
+		ProviderSlug:        uc.DefaultConfig.ProviderSlug,
+		Scope:               pc.Scope,
+
+		SessionLifetimeTTL: sc.TTLConfig.Lifetime,
+		SessionValidTTL:    sc.TTLConfig.Valid,
+		GracePeriodTTL:     sc.TTLConfig.GracePeriod,
 	}
 
-	p := providers.New(opts.Provider, providerData, opts.StatsdClient)
-	return providers.NewSingleFlightProvider(p, opts.StatsdClient), nil
+	p := providers.New(pc.ProviderType, providerData, statsdClient)
+	return providers.NewSingleFlightProvider(p, statsdClient), nil
 }
 
-func validateCookieName(o *Options, msgs []string) []string {
-	cookie := &http.Cookie{Name: o.CookieName}
-	if cookie.String() == "" {
-		return append(msgs, fmt.Sprintf("invalid cookie name: %q", o.CookieName))
+// SetStatsdClient sets the statsd client as a functional option
+func SetStatsdClient(statsdClient *statsd.Client) func(*OAuthProxy) error {
+	return func(op *OAuthProxy) error {
+		op.StatsdClient = statsdClient
+		return nil
 	}
-	return msgs
 }
 
 func parseEnvironment(environ []string) map[string]string {

--- a/internal/proxy/options_test.go
+++ b/internal/proxy/options_test.go
@@ -2,132 +2,262 @@ package proxy
 
 import (
 	"fmt"
-	"strings"
+	"io/ioutil"
+	"net/url"
+	"os"
+	"reflect"
 	"testing"
 	"time"
 
 	"github.com/buzzfeed/sso/internal/pkg/testutil"
+	"github.com/datadog/datadog-go/statsd"
 )
 
-var testEncodedCookieSecret = "tJgzIEug8M/6Asjn5mvpWxxef5d5duU7BwpuD0GCHRI="
-
-func testOptions() *Options {
-	o := NewOptions()
-	o.CookieSecret = testEncodedCookieSecret
-	o.ClientID = "bazquux"
-	o.ClientSecret = "xyzzyplugh"
-	o.DefaultAllowedEmailDomains = []string{"*"}
-	o.DefaultProviderSlug = "idp"
-	o.ProviderURLString = "https://www.example.com"
-	o.UpstreamConfigsFile = "testdata/upstream_configs.yml"
-	o.Cluster = "sso"
-	o.Scheme = "http"
-	o.StatsdHost = "localhost"
-	o.StatsdPort = 1234
-	o.testTemplateVars = map[string]string{
-		"cluster":     "sso",
-		"root_domain": "dev",
-	}
-	o.DefaultUpstreamTimeout = time.Duration(1) * time.Second
-	return o
-}
-
-func errorMsg(msgs []string) string {
-	result := make([]string, 0)
-	result = append(result, "Invalid configuration:")
-	result = append(result, msgs...)
-	return strings.Join(result, "\n  ")
-}
-
-func TestNewOptions(t *testing.T) {
-	o := NewOptions()
-
-	upstreamConfig := &UpstreamConfig{
-		Service: "testService",
-	}
-	o.upstreamConfigs = []*UpstreamConfig{upstreamConfig}
-
-	err := o.Validate()
-	testutil.NotEqual(t, nil, err)
-
-	expected := errorMsg([]string{
-		"missing setting: cluster",
-		"missing setting: provider-url",
-		"missing setting: upstream-configs",
-		"missing setting: cookie-secret",
-		"missing setting: client-id",
-		"missing setting: client-secret",
-		"missing setting: statsd-host",
-		"missing setting: statsd-port",
-		"missing setting: ALLOWED_EMAIL_DOMAINS, ALLOWED_EMAIL_ADDRESSES, ALLOWED_GROUPS default in environment or override in upstream config in the following upstreams: [testService]",
-		"Invalid value for COOKIE_SECRET; must decode to 32 or 64 bytes, but decoded to 0 bytes",
-	})
-	testutil.Equal(t, expected, err.Error())
-}
-
-func TestInitializedOptions(t *testing.T) {
-	o := testOptions()
-	testutil.Equal(t, nil, o.Validate())
-}
-
-func TestProviderURLValidation(t *testing.T) {
+func TestSetUpstreamConfigs(t *testing.T) {
 	testCases := []struct {
-		name                              string
-		providerURLString                 string
-		providerURLInternalString         string
-		expectedError                     string
-		expectedProviderURLInternalString string
-		expectedSignInURL                 string
+		name            string
+		upstreamConfigs *UpstreamConfigs
+		serverConfig    ServerConfig
+		expectedErrMsg  string
 	}{
 		{
-			name:              "http scheme preserved",
-			providerURLString: "http://provider.example.com",
-			expectedSignInURL: "http://provider.example.com/idp/sign_in",
+			name: "missing settings error",
+			upstreamConfigs: &UpstreamConfigs{
+				upstreamConfigs: []*UpstreamConfig{
+					{Service: "invalidUpstream", Timeout: time.Duration(24) * time.Second},
+					{Service: "validUpstream", Timeout: time.Duration(24) * time.Second, AllowedGroups: []string{"customGroup"}},
+				},
+			},
+			serverConfig: ServerConfig{
+				TimeoutConfig: TimeoutConfig{Write: time.Duration(5) * time.Second},
+			},
+			expectedErrMsg: "missing setting: ALLOWED_EMAIL_DOMAINS, ALLOWED_EMAIL_ADDRESSES, ALLOWED_GROUPS default in environment or override in upstream config in the following upstreams: [invalidUpstream]",
 		},
 		{
-			name:              "https scheme preserved",
-			providerURLString: "https://provider.example.com",
-			expectedSignInURL: "https://provider.example.com/idp/sign_in",
-		},
-		{
-			name:                              "proxy provider url string based on providerURL",
-			providerURLString:                 "https://provider.example.com",
-			expectedProviderURLInternalString: "",
-		},
-		{
-			name:                              "proxy provider url string based on proxyProviderURL",
-			providerURLString:                 "https://provider.example.com",
-			providerURLInternalString:         "https://provider-internal.example.com",
-			expectedProviderURLInternalString: "https://provider-internal.example.com",
-		},
-		{
-			name:              "scheme required",
-			providerURLString: "//provider.example.com",
-			expectedError: errorMsg([]string{
-				`invalid value for provider-url: provider-url must include scheme and host`,
-			}),
-		},
-		{
-			name:              "scheme and host required",
-			providerURLString: "/foo",
-			expectedError: errorMsg([]string{
-				`invalid value for provider-url: provider-url must include scheme and host`,
-			}),
-		},
-		{
-			name:              "invalid url rejected",
-			providerURLString: "%ZZZ",
-			expectedError: errorMsg([]string{
-				`invalid value for provider-url: parse "%ZZZ": invalid URL escape "%ZZ"`,
-			}),
+			name: "upstream config successfully set",
+			upstreamConfigs: &UpstreamConfigs{
+				upstreamConfigs: []*UpstreamConfig{
+					{
+						Service:               "bar",
+						Timeout:               time.Duration(24) * time.Second,
+						AllowedEmailDomains:   []string{"foo.com"},
+						AllowedEmailAddresses: []string{"bar@bar.com"},
+						AllowedGroups:         []string{"customGroup"},
+					},
+				},
+			},
+			serverConfig: ServerConfig{
+				TimeoutConfig: TimeoutConfig{
+					Write: time.Duration(5) * time.Second,
+				},
+			},
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			o := testOptions()
-			o.ProviderURLString = tc.providerURLString
-			o.ProviderURLInternalString = tc.providerURLInternalString
-			err := o.Validate()
+
+			var serverConfigTimeoutShouldChange bool
+			if *&tc.upstreamConfigs.upstreamConfigs[0].Timeout > tc.serverConfig.TimeoutConfig.Write {
+				serverConfigTimeoutShouldChange = true
+			}
+
+			err := SetUpstreamConfigs(tc.upstreamConfigs, CookieConfig{}, &tc.serverConfig)
+			if err == nil && tc.expectedErrMsg != "" {
+				t.Fatalf("expected error but error was nil")
+			}
+			if err != nil && tc.expectedErrMsg == "" {
+				t.Fatalf("expected no error but got: %v", err)
+			}
+			if err != nil && err.Error() != tc.expectedErrMsg {
+				t.Logf("expected: %q", tc.expectedErrMsg)
+				t.Logf("     got: %q", err)
+				t.Fatalf("unexpected error while setting upstream configs")
+			}
+
+			if serverConfigTimeoutShouldChange {
+				if tc.serverConfig.TimeoutConfig.Write != *&tc.upstreamConfigs.upstreamConfigs[0].Timeout {
+					t.Logf("server timeout: %v", tc.serverConfig.TimeoutConfig.Write)
+					t.Logf("upstream timeout: %v", *&tc.upstreamConfigs.upstreamConfigs[0].Timeout)
+					t.Fatalf("expected server timeout to be reset to match upstream timeout")
+				}
+			}
+		})
+	}
+}
+
+func TestUpstreamConfigsFile(t *testing.T) {
+	testCases := []struct {
+		name            string
+		rawConfig       []byte
+		upstreamConfigs *UpstreamConfigs
+		serverConfig    ServerConfig
+		configFilePath  string
+		expectedErrMsg  string
+
+		wantConfig *UpstreamConfig
+	}{
+		{
+			name:           "invalid upstream config file path",
+			configFilePath: "foo",
+			upstreamConfigs: &UpstreamConfigs{
+				DefaultConfig: DefaultConfig{
+					AllowedGroups: []string{"defaultGroup"},
+					ResetDeadline: time.Duration(5) * time.Second,
+				},
+				Scheme: "https",
+			},
+			serverConfig: ServerConfig{
+				TimeoutConfig: TimeoutConfig{
+					Write: time.Duration(5) * time.Second,
+				},
+			},
+			wantConfig:     &UpstreamConfig{},
+			expectedErrMsg: "error reading upstream configs file: open foo: no such file or directory",
+		},
+
+		{
+			name: "upstream configs successfully created from file and config vars, with defaults holding",
+			rawConfig: []byte(`
+- service: bar
+  default:
+    from: bar.{{cluster}}.{{root_domain}}
+    to: bar-internal.{{cluster}}.{{root_domain}}
+    options:
+      reset_deadline: 100ms
+`),
+
+			upstreamConfigs: &UpstreamConfigs{
+				DefaultConfig: DefaultConfig{
+					AllowedGroups: []string{"defaultGroup"},
+					ResetDeadline: time.Duration(5) * time.Second,
+				},
+				Scheme: "https",
+			},
+
+			serverConfig: ServerConfig{
+				TimeoutConfig: TimeoutConfig{
+					Write: time.Duration(5) * time.Second,
+				},
+			},
+
+			wantConfig: &UpstreamConfig{
+				Service: "bar",
+				// AllowedGroups: default config value should be used
+				AllowedGroups: []string{"defaultGroup"},
+				// ResetDeadline: upstream config value should be used, default ignored
+				ResetDeadline: time.Duration(100) * time.Millisecond,
+				RouteConfig: RouteConfig{
+					From: "bar.sso.test",
+					To:   "bar-internal.sso.test",
+				},
+				Route: &SimpleRoute{
+					FromURL: &url.URL{
+						Scheme: "https",
+						Host:   "bar.sso.test",
+					},
+					ToURL: &url.URL{
+						Scheme: "https",
+						Host:   "bar-internal.sso.test",
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			os.Setenv("SSO_CONFIG_CLUSTER", "sso")
+			os.Setenv("SSO_CONFIG_ROOT_DOMAIN", "test")
+
+			if tc.configFilePath != "" {
+				tc.upstreamConfigs.ConfigsFile = tc.configFilePath
+			} else {
+				tempFile, _ := ioutil.TempFile("", "")
+				_, err := tempFile.Write(tc.rawConfig)
+				if err != nil {
+					t.Fatalf("error writing to file")
+				}
+				tc.upstreamConfigs.ConfigsFile = tempFile.Name()
+			}
+
+			err := SetUpstreamConfigs(tc.upstreamConfigs, CookieConfig{}, &tc.serverConfig)
+			if err == nil && tc.expectedErrMsg != "" {
+				t.Fatalf("expected error but error was nil")
+			}
+			if err != nil && tc.expectedErrMsg == "" {
+				t.Fatalf("expected no error but got: %v", err)
+			}
+			if err != nil && err.Error() != tc.expectedErrMsg {
+				t.Logf("expected: %q", tc.expectedErrMsg)
+				t.Logf("     got: %q", err)
+				t.Fatalf("unexpected error while setting upstream configs")
+			} else if err != nil && err.Error() == tc.expectedErrMsg {
+				return
+			}
+
+			gotConfigs := &*tc.upstreamConfigs.upstreamConfigs[0]
+			if !reflect.DeepEqual(gotConfigs, tc.wantConfig) {
+				fmt.Printf("expected config: %+v", *&tc.wantConfig)
+				fmt.Printf("     got config: %+v", gotConfigs)
+				t.Fatalf("expected configs to be equal")
+
+			}
+		})
+	}
+}
+
+func TestProviderURLValidation(t *testing.T) {
+	testCases := []struct {
+		name                        string
+		providerURLExternal         string
+		providerURLInternal         string
+		expectedError               string
+		expectedProviderURLInternal string
+		expectedSignInURL           string
+	}{
+		{
+			name:                "http scheme preserved",
+			providerURLExternal: "http://provider.example.com",
+			expectedSignInURL:   "http://provider.example.com/idp/sign_in",
+		},
+		{
+			name:                "https scheme preserved",
+			providerURLExternal: "https://provider.example.com",
+			expectedSignInURL:   "https://provider.example.com/idp/sign_in",
+		},
+		{
+			name:                        "proxy provider url string based on providerURL",
+			providerURLExternal:         "https://provider.example.com",
+			expectedProviderURLInternal: "",
+		},
+		{
+			name:                        "proxy provider url string based on proxyProviderURL",
+			providerURLExternal:         "https://provider.example.com",
+			providerURLInternal:         "https://provider-internal.example.com",
+			expectedProviderURLInternal: "https://provider-internal.example.com",
+		},
+		{
+			name:                "scheme required",
+			providerURLExternal: "//provider.example.com",
+			expectedError:       "invalid provider.providerurl config: providerurl.external must include scheme and host",
+		},
+		{
+			name:                "scheme and host required",
+			providerURLExternal: "/foo",
+			expectedError:       "invalid provider.providerurl config: providerurl.external must include scheme and host",
+		},
+		{
+			name:                "invalid url rejected",
+			providerURLExternal: "%ZZZ",
+			expectedError:       "invalid provider.providerurl config: parse \"%ZZZ\": invalid URL escape \"%ZZ\"",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			config := DefaultProxyConfig()
+			config.ProviderConfig.ProviderURLConfig.External = tc.providerURLExternal
+			config.ProviderConfig.ProviderURLConfig.Internal = tc.providerURLInternal
+			err := config.ProviderConfig.Validate()
 
 			if tc.expectedError != "" {
 				if err == nil {
@@ -140,53 +270,18 @@ func TestProviderURLValidation(t *testing.T) {
 				return
 			}
 
-			provider, err := newProvider(o, &UpstreamConfig{ProviderSlug: "idp"})
+			statsdClient, _ := statsd.New("127.0.0.1:8125")
+			config.UpstreamConfigs.DefaultConfig.ProviderSlug = "idp"
+			provider, err := newProvider(config.ClientConfig, config.ProviderConfig, config.SessionConfig, config.UpstreamConfigs, statsdClient)
 			if err != nil {
 				t.Fatalf("unexpected err creating provider: %v", err)
 			}
 			if tc.expectedSignInURL != "" {
 				testutil.Equal(t, provider.Data().SignInURL.String(), tc.expectedSignInURL)
 			}
-			if tc.expectedProviderURLInternalString != "" {
-				testutil.Equal(t, provider.Data().ProviderURLInternal.String(), tc.expectedProviderURLInternalString)
+			if tc.expectedProviderURLInternal != "" {
+				testutil.Equal(t, provider.Data().ProviderURLInternal.String(), tc.expectedProviderURLInternal)
 			}
 		})
 	}
-}
-
-func TestBase64CookieSecret(t *testing.T) {
-	o := testOptions()
-	testutil.Equal(t, nil, o.Validate())
-
-	// 32 byte, base64 (urlsafe) encoded key
-	o.CookieSecret = testEncodedCookieSecret
-	testutil.Equal(t, nil, o.Validate())
-
-	// 32 byte, base64 (urlsafe) encoded key, w/o padding
-	o.CookieSecret = testEncodedCookieSecret
-	testutil.Equal(t, nil, o.Validate())
-
-	testutil.Equal(t, nil, o.Validate())
-}
-
-func TestValidateCookie(t *testing.T) {
-	o := testOptions()
-	o.CookieName = "_valid_cookie_name"
-	testutil.Equal(t, nil, o.Validate())
-}
-
-func TestValidateCookieBadName(t *testing.T) {
-	o := testOptions()
-	o.CookieName = "_bad_cookie_name{}"
-	err := o.Validate()
-	testutil.Equal(t, err.Error(), "Invalid configuration:\n"+
-		fmt.Sprintf("  invalid cookie name: %q", o.CookieName))
-}
-
-func TestPassAccessToken(t *testing.T) {
-	o := testOptions()
-	testutil.Equal(t, false, o.PassAccessToken)
-	o.PassAccessToken = true
-	testutil.Equal(t, nil, o.Validate())
-	testutil.Equal(t, true, o.PassAccessToken)
 }

--- a/internal/proxy/proxy_config.go
+++ b/internal/proxy/proxy_config.go
@@ -55,6 +55,8 @@ type UpstreamConfig struct {
 	AllowedEmailDomains   []string
 	AllowedEmailAddresses []string
 	TLSSkipVerify         bool
+	SkipAuthPreflight     bool
+	PassAccessToken       bool
 	PreserveHost          bool
 	HMACAuth              hmacauth.HmacAuth
 	Timeout               time.Duration
@@ -97,6 +99,8 @@ type OptionsConfig struct {
 	AllowedEmailDomains   []string          `yaml:"allowed_email_domains"`
 	AllowedEmailAddresses []string          `yaml:"allowed_email_addresses"`
 	TLSSkipVerify         bool              `yaml:"tls_skip_verify"`
+	SkipAuthPreflight     bool              `yaml:"skip_auth_preflight"`
+	PassAccessToken       bool              `yaml:"pass_access_token"`
 	PreserveHost          bool              `yaml:"preserve_host"`
 	Timeout               time.Duration     `yaml:"timeout"`
 	ResetDeadline         time.Duration     `yaml:"reset_deadline"`

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -21,8 +21,15 @@ func randSeq(n int) string {
 }
 
 func TestPingHandler(t *testing.T) {
-	opts := NewOptions()
-	sso, err := New(opts)
+	config := DefaultProxyConfig()
+	statsdClient, err := NewStatsdClient(
+		config.MetricsConfig.StatsdConfig.Host,
+		config.MetricsConfig.StatsdConfig.Port)
+	if err != nil {
+		t.Fatalf("unexpected error creating statsd client: %v", err)
+	}
+
+	sso, err := New(config, statsdClient)
 	if err != nil {
 		t.Fatalf("unexpected err starting sso: %v", err)
 	}


### PR DESCRIPTION
## Problem

`sso_auth` was migrated to use `go-micro` in https://github.com/buzzfeed/sso/pull/212 to manage variable configuration. `sso_proxy` is still using the original outdated methods and should be updated to also use `go-micro`

## Solution

Update `sso_proxy` to use `go-micro`. No feature changes are intended to be part of this change, *apart from* the behaviour of the following two variables:
- `SKIP_AUTH_PREFLIGHT` and `PASS_ACCESS_TOKEN` are now **upstream specific** and should be specified as part of upstream configs, **not** global/environment variables.

In general, the patterns used in this pull request are the same ones used in https://github.com/buzzfeed/sso/pull/212

## Review notes
Some notes to support reviewing:
- The bulk of changes here consist of creating the new configuration structure, and altering functions and methods to reference that new structure.
- Numerous functions have been moved out of `oauthproxy.go` and into `options.go`:
  - `SetCookieStore`
  - `SetRequestSigner`
  - `SetUpstreamConfig`
  - `SetProxyHandler`
  - `SetValidators`
  - `SetProvider`

- A new function, `SetUpstreamConfigs`, largely consists of some logic that was in the `options.Validate` method.  


#### The below table shows all old variables, and their new equivalent version.

|   old	| new  	|
|---	|---	|
| **session configs** | 
|  COOKIE_NAME 	 |   SESSION_COOKIE_NAME	|
|   COOKIE_SECRET  | SESSION_COOKIE_SECRET   	|
|   COOKIE_EXPIRE 	 |   SESSION_COOKIE_EXPIRE	|
|   COOKIE_DOMAIN	|   SESSION_COOKIE_DOMAIN 	|
|   COOKIE_HTTP_ONLY	 |   SESSION_COOKIE_HTTPONLY	|
| COOKIE_SECURE | SESSION_COOKIE_SECURE |
|   SESSION_LIFETIME_TTL   |   SESSION_TTL_LIFETIME|
|   SESSION_VALID_TTL   |   SESSION_TTL_VALID	|
|   GRACE_PERIOD_TTL   |      SESSION_TTL_GRACEPERIOD|
| --- | 
| **upstream configs**	|
|   DEFAULT_ALLOWED_EMAIL_DOMAINS	|   UPSTREAM_DEFAULT_EMAIL_DOMAINS	|
|  DEFAULT_ALLOWED_EMAIL_ADDRESSES 	|   UPSTREAM_DEFAULT_EMAIL_ADDRESSES	|
|   DEFAULT_ALLOWED_GROUPS	|   UPSTREAM_DEFAULT_GROUPS	|
|   DEFAULT_UPSTREAM_TIMEOUT	|   UPSTREAM_DEFAULT_TIMEOUT	|
|   DEFAULT_UPSTREAM_TCP_RESET_DEADLINE	|   UPSTREAM_DEFAULT_RESETDEADLINE	|
|   	|   	|
|   UPSTREAM_CONFIGS	|   UPSTREAM_CONFIGSFILE	|
| | |
|   CLUSTER	|   UPSTREAM_CLUSTER	|
| SCHEME | UPSTREAM_SCHEME |
| PROVIDER | UPSTREAM_DEFAULT_PROVIDER |
| --- |
|   **server configs**	|
|   PORT	|  SERVER_PORT 	|
|   SHUTDOWN_TIMEOUT	|   SERVER_TIMEOUT_SHUTDOWN	|
|   TCP_READ_TIMEOUT	|   SERVER_TIMEOUT_READ	|
|   TCP_WRITE_TIMEOUT	|   SERVER_TIMEOUT_WRITE	|
| --- |
| **metrics configs**	|
|   STATSD_PORT	|   METRICS_STATSD_HOST	|
|   STATSD_HOST	|   METRICS_STATSD_PORT	|
| --- |
| **logging configs** |
|   REQUEST_LOGGING	|   LOGGING_ENABLE	|
|   	|   ~LOGGING_LEVEL~	|
| --- |
| **client configs**	|
|   CLIENT_ID	|   CLIENT_ID	|
|   CLIENT_SECRET	|   CLIENT_SECRET	|
| --- |
|**request signature configs**	|
|   REQUEST_SIGNATURE_KEY	|   REQUESTSIGNER_KEY	|
| --- |
| **provider configs**|
|   PROVIDER	|   PROVIDER_TYPE	|
|   PROVIDER_URL	|   PROVIDER_URL_EXTERNAL	|
|   PROVIDER_URL_INTERNAL | PROVIDER_URL_INTERNAL |
|   SCOPE   | PROVIDER_SCOPE  |
