### PR TITLE
sso-proxy: reject request if any validation fails (fixes #125)

### DIFF
--- a/internal/auth/authenticator.go
+++ b/internal/auth/authenticator.go
@@ -227,7 +227,7 @@ func (p *Authenticator) authenticate(rw http.ResponseWriter, req *http.Request) 
 	}
 
 	errors := options.RunValidators(p.Validators, session)
-	if len(errors) == len(p.Validators) {
+	if len(errors) != 0 {
 		logger.WithUser(session.Email).Info(
 			fmt.Sprintf("permission denied: unauthorized: %q", errors))
 		return nil, ErrUserNotAuthorized
@@ -583,7 +583,7 @@ func (p *Authenticator) getOAuthCallback(rw http.ResponseWriter, req *http.Reque
 	// - for p.provider.ValidateGroup see providers/google.go#ValidateGroup for more info
 
 	errors := options.RunValidators(p.Validators, session)
-	if len(errors) == len(p.Validators) {
+	if len(errors) != 0 {
 		tags := append(tags, "error:invalid_email")
 		p.StatsdClient.Incr("application_error", tags, 1.0)
 		logger.WithRemoteAddress(remoteAddr).WithUser(session.Email).Info(

--- a/internal/proxy/oauthproxy.go
+++ b/internal/proxy/oauthproxy.go
@@ -570,7 +570,7 @@ func (p *OAuthProxy) OAuthCallback(rw http.ResponseWriter, req *http.Request) {
 	// set cookie, or deny
 
 	errors := options.RunValidators(p.Validators, session)
-	if len(errors) == len(p.Validators) {
+	if len(errors) != 0 {
 		tags = append(tags, "error:validation_failed")
 		p.StatsdClient.Incr("application_error", tags, 1.0)
 		logger.WithRemoteAddress(remoteAddr).WithUser(session.Email).Info(


### PR DESCRIPTION
## Problem

Group validations were being ignored

## Solution

Fail validation when _any_ validation fails, ATM it looks to only fail when _all_ fail.

## Notes

I'm just a bit worried I'm missing something :-) (Not familiar with codebase)