### PR TITLE
fillcache: remove group from cache if it can't be found by the identity provider

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859 // indirect
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
-	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7
+	golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898
 	google.golang.org/api v0.5.0
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -363,8 +363,8 @@ golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBn
 golang.org/x/tools v0.0.0-20190530171427-2b03ca6e44eb/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190603231351-8aaa1484dc10 h1:9LyHDLeGJwq8p/x0xbF8aG63cLC6EDjlNbGYc7dacDc=
 golang.org/x/tools v0.0.0-20190603231351-8aaa1484dc10/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
-golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
-golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 h1:/atklqdjdhuosWIl6AIbOeHJjicWYPqR9bpxqxYG2pA=
+golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.5.0 h1:lj9SyhMzyoa38fgFF0oO2T6pjs5IzkLPKfVtxpyCRMM=
 google.golang.org/api v0.5.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=

--- a/internal/auth/providers/google_admin.go
+++ b/internal/auth/providers/google_admin.go
@@ -7,11 +7,12 @@ import (
 	"time"
 
 	"github.com/buzzfeed/sso/internal/auth/circuit"
+	"github.com/buzzfeed/sso/internal/pkg/groups"
 	log "github.com/buzzfeed/sso/internal/pkg/logging"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
-	"google.golang.org/api/admin/directory/v1"
+	admin "google.golang.org/api/admin/directory/v1"
 	"google.golang.org/api/googleapi"
 
 	"github.com/datadog/datadog-go/statsd"
@@ -96,8 +97,8 @@ func (gs *GoogleAdminService) listMemberships(groupName string, maxDepth, curren
 					}
 					err = ErrBadRequest
 				case 404:
-					logger.WithUserGroup(groupName).Warn("could not list memberships, user group not found")
-					err = ErrGroupNotFound
+					logger.WithUserGroup(groupName).Warn("could not list memberships, user group not found; removing group from cache")
+					err = groups.ErrGroupNotFound
 				case 429:
 					err = ErrRateLimitExceeded
 				case 503:

--- a/internal/auth/providers/providers.go
+++ b/internal/auth/providers/providers.go
@@ -15,9 +15,6 @@ var (
 	// ErrTokenRevoked represents 400 Token Revoked errors
 	ErrTokenRevoked = errors.New("TOKEN_REVOKED")
 
-	// ErrGroupNotFound respesnts a 404 Not Found errors for groups
-	ErrGroupNotFound = errors.New("GROUP_NOT_FOUND")
-
 	// ErrRateLimitExceeded represents 429 Rate Limit Exceeded errors
 	ErrRateLimitExceeded = errors.New("RATE_LIMIT_EXCEEDED")
 

--- a/internal/pkg/groups/fillcache.go
+++ b/internal/pkg/groups/fillcache.go
@@ -1,6 +1,7 @@
 package groups
 
 import (
+	"errors"
 	"fmt"
 	"math/rand"
 	"sync"
@@ -13,6 +14,8 @@ import (
 const (
 	defaultMaxJitter = 50 * time.Millisecond
 )
+
+var ErrGroupNotFound = errors.New("Group not found while running fill func")
 
 // MemberSetCache represents a cache of members of a set
 type MemberSetCache interface {
@@ -92,6 +95,10 @@ func (c *FillCache) Update(group string) bool {
 	if err == nil {
 		c.cache[group] = val
 		return true
+	}
+
+	if err == ErrGroupNotFound {
+		delete(c.cache, group)
 	}
 
 	c.StatsdClient.Incr("groups_cache.error",

--- a/internal/pkg/groups/fillcache_test.go
+++ b/internal/pkg/groups/fillcache_test.go
@@ -44,7 +44,7 @@ func TestFillCacheUpdate(t *testing.T) {
 
 			// ("group removed if it can't be found")
 			// In order to test a group is removed from the cache if it can't be found, we
-			// fill the cache, check the group is present, then update the cache before checking
+			// fill the cache, check the key is present, then update the cache before checking
 			// the key has been removed
 			if tc.fillError == ErrGroupNotFound {
 				temporaryCacheKey := "groupKeyB"
@@ -67,12 +67,12 @@ func TestFillCacheUpdate(t *testing.T) {
 			}
 
 			ok := fillCache.Update(cacheKey)
-			if tc.updated != ok {
+			if ok != tc.updated {
 				t.Errorf("expected updated to be %v but was %v", tc.updated, ok)
 			}
 
 			// as well as checking the key is actually in the cache when it should be, this also tests that
-			// unrelated groups aren't deleted when another group can't be found within the "group removed if it can't be found" test
+			// unrelated groups aren't deleted within the "group removed if it can't be found" test
 			if tc.updated == true || tc.fillError == ErrGroupNotFound {
 				_, ok = fillCache.Get(cacheKey)
 				if ok != tc.updated {

--- a/internal/pkg/groups/fillcache_test.go
+++ b/internal/pkg/groups/fillcache_test.go
@@ -43,7 +43,7 @@ func TestFillCacheUpdate(t *testing.T) {
 
 			// ("group removed if it can't be found")
 			// In order to test a group is removed from the cache if it can't be found, we first
-			// fill the cache and check the group is present. Further down, we then check for it's
+			// fill the cache and check the group is present. Further down, we then check for its
 			// existence again after updating the cache.
 			if tc.fillError == ErrGroupNotFound {
 				fillCache.cache["groupKey"] = tc.members


### PR DESCRIPTION
## Problem
Groups aren't actively removed from the fillcache if we find that the group can't be found (based on return codes from the identity provider).

## Solution

If the group can't be found by the identity provider, then delete it from the fillcache.