### PR TITLE
codecov: update to project threshold to explicit %

### DIFF
--- a/.codecov/codecov.yml
+++ b/.codecov/codecov.yml
@@ -14,7 +14,8 @@ coverage:
   status:
     project:
       default:
-        threshold: 2
+        threshold: 2%
+        base: auto
     patch: no
     changes: no
 


### PR DESCRIPTION
## Problem

Codecov appears to be incorrectly failing some pull request checks due to the `project` status check. If I understand correctly, our Codecov configuration should mean that the `project` check should fail if the change results in a 2% drop in overall coverage. 

https://github.com/buzzfeed/sso/pull/279 is failing due to a 0.47% drop in project coverage.
 
## Solution

It seems the Codecov docs have been updated to show the threshold being set explicitly as a `%`, and some past issues seem to suggest that this may affect how it works, e.g.  https://community.codecov.io/t/threshold-confusion/88. 
It's unclear if this is the cause, but seems sensible to update regardless and to rule it out.
