### PR TITLE
Proxy path-components with %-escaped characters in tact.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ ENV GO111MODULE=on
 
 WORKDIR /go/src/github.com/buzzfeed/sso
 
+COPY ./go.mod ./go.sum ./
+RUN go mod download
 COPY . .
 RUN cd cmd/sso-auth && go build -mod=readonly -o /bin/sso-auth
 RUN cd cmd/sso-proxy && go build -mod=readonly -o /bin/sso-proxy

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/benbjohnson/clock v0.0.0-20161215174838-7dc76406b6d3
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/datadog/datadog-go v0.0.0-20180822151419-281ae9f2d895
+	github.com/gorilla/mux v1.7.2
 	github.com/gorilla/websocket v1.4.0
 	github.com/imdario/mergo v0.3.7
 	github.com/kelseyhightower/envconfig v1.3.0
@@ -13,7 +14,7 @@ require (
 	github.com/micro/go-micro v1.5.0
 	github.com/miscreant/miscreant-go v0.0.0-20181010193435-325cbd69228b
 	github.com/mitchellh/mapstructure v1.1.2
-	github.com/rakyll/statik v0.1.6
+	github.com/rakyll/statik v0.1.7
 	github.com/sirupsen/logrus v1.4.2
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859 // indirect
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,7 @@ github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/gax-go/v2 v2.0.4 h1:hU4mGcQI4DaAYW+IbTun+2qEZVFxK0ySjQLTbS0VQKc=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/gorilla/handlers v1.4.0/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
+github.com/gorilla/mux v1.7.2 h1:zoNxOV7WjqXptQOVngLmcSQgXmgk4NMz1HibBchjl/I=
 github.com/gorilla/mux v1.7.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
@@ -239,8 +240,8 @@ github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7z
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/prometheus/tsdb v0.8.0/go.mod h1:fSI0j+IUQrDd7+ZtR9WKIGtoYAYAJUKcKhYLG25tN4g=
-github.com/rakyll/statik v0.1.6 h1:uICcfUXpgqtw2VopbIncslhAmE5hwc4g20TEyEENBNs=
-github.com/rakyll/statik v0.1.6/go.mod h1:OEi9wJV/fMUAGx1eNjq75DKDsJVuEv1U0oYdX6GX8Zs=
+github.com/rakyll/statik v0.1.7 h1:OF3QCZUuyPxuGEP7B4ypUa7sB/iHtqOTDYZXGM8KOdQ=
+github.com/rakyll/statik v0.1.7/go.mod h1:AlZONWzMtEnMs7W4e/1LURLiI49pIMmp6V9Unghqrcc=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=

--- a/internal/auth/authenticator.go
+++ b/internal/auth/authenticator.go
@@ -17,6 +17,7 @@ import (
 	"github.com/buzzfeed/sso/internal/pkg/templates"
 
 	"github.com/datadog/datadog-go/statsd"
+	"github.com/gorilla/mux"
 )
 
 // Authenticator stores all the information associated with proxying the request.
@@ -105,7 +106,8 @@ func NewAuthenticator(config Configuration, optionFuncs ...func(*Authenticator) 
 
 func (p *Authenticator) newMux() http.Handler {
 	// we setup our service mux to handle service routes that use the required host header
-	serviceMux := http.NewServeMux()
+	serviceMux := mux.NewRouter()
+	serviceMux.UseEncodedPath()
 	serviceMux.HandleFunc("/start", p.withMethods(p.OAuthStart, "GET"))
 	serviceMux.HandleFunc("/sign_in", p.withMethods(p.validateClientID(p.validateRedirectURI(p.validateSignature(p.SignIn))), "GET"))
 	serviceMux.HandleFunc("/sign_out", p.withMethods(p.validateRedirectURI(p.validateSignature(p.SignOut)), "GET", "POST"))

--- a/internal/auth/static_files_test.go
+++ b/internal/auth/static_files_test.go
@@ -42,6 +42,12 @@ func TestStaticFiles(t *testing.T) {
 			uri:            "http://localhost/static/../config.yml",
 			expectedStatus: http.StatusMovedPermanently,
 		},
+		{
+			// this should NOT result in a 301, since escaped-paths are propagated as-is.
+			name:           "no directory escape",
+			uri:            "http://localhost/static/https:%2F%2Fexample.com",
+			expectedStatus: http.StatusNotFound,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/proxy/oauthproxy.go
+++ b/internal/proxy/oauthproxy.go
@@ -18,6 +18,7 @@ import (
 	"github.com/buzzfeed/sso/internal/proxy/providers"
 
 	"github.com/datadog/datadog-go/statsd"
+	"github.com/gorilla/mux"
 )
 
 // HMACSignatureHeader is the header name where the signed request header is stored.
@@ -229,14 +230,15 @@ func NewOAuthProxy(opts *Options, optFuncs ...func(*OAuthProxy) error) (*OAuthPr
 
 // Handler returns a http handler for an OAuthProxy
 func (p *OAuthProxy) Handler() http.Handler {
-	mux := http.NewServeMux()
+	mux := mux.NewRouter()
+	mux.UseEncodedPath()
 	mux.HandleFunc("/favicon.ico", p.Favicon)
 	mux.HandleFunc("/robots.txt", p.RobotsTxt)
 	mux.HandleFunc("/oauth2/v1/certs", p.Certs)
 	mux.HandleFunc("/oauth2/sign_out", p.SignOut)
 	mux.HandleFunc("/oauth2/callback", p.OAuthCallback)
 	mux.HandleFunc("/oauth2/auth", p.AuthenticateOnly)
-	mux.HandleFunc("/", p.Proxy)
+	mux.PathPrefix("/").HandlerFunc(p.Proxy)
 
 	// Global middleware, which will be applied to each request in reverse
 	// order as applied here (i.e., we want to validate the host _first_ when


### PR DESCRIPTION
## Problem

When proxying to a path with a %-encoded `/` character (i.e. `%2F`), the Golang `http.ServeMux` class auto-unwraps the %-encoding. It then uses `path.Clean()` to "helpfully" normalize successive `/` characters (e.g. `/a/b//c` to `/a/b/c`, `/a/b/../c` to `/a`, etc).

Though admittedly an edge-case, the unintended side-effect is that a URL whose path contains a %-encoded URL will be proxied incorrectly. Fo instance, the URL
`https://example.com/path/http:%2F%2Ffoo.com/`
will be proxied to
`https://example.com/path/http:/foo.com/`.

## Solution

Replace use of `http.ServeMux` with the `mux.Router` class from the popular https://github.com/gorilla/mux library, which allows use of `URL.EscapedPath()` in lieu of directly reading `URL.Path`. This preserves the %-wrapping of path-components, which in turn prevents `path.Clean()` from errantly rewriting the path.

## Notes

The motivating example derives from the popular open-source Jenkins project, which uses URLs in such a form to check the health of a reverse-proxy - Hence this bug causes a Jenkins instance behind an SSO deployment to report a "broken" reverse-proxy configuration.