### PR TITLE
sso_proxy: fix session revalidation/refresh when group validation isn't being used

### DIFF
--- a/internal/proxy/providers/sso.go
+++ b/internal/proxy/providers/sso.go
@@ -181,6 +181,9 @@ func (p *SSOProvider) ValidateGroup(email string, allowedGroups []string, access
 
 	logger.WithUser(email).WithAllowedGroups(allowedGroups).Info("validating groups")
 	inGroups := []string{}
+	if len(allowedGroups) == 0 {
+		return inGroups, true, nil
+	}
 
 	userGroups, err := p.UserGroups(email, allowedGroups, accessToken)
 	if err != nil {

--- a/internal/proxy/providers/sso_test.go
+++ b/internal/proxy/providers/sso_test.go
@@ -144,11 +144,11 @@ func TestSSOProviderGroups(t *testing.T) {
 		ProfileStatus    int
 	}{
 		{
-			Name:             "invalid when no group id set",
+			Name:             "valid when no group id set",
 			Email:            "michael.bland@gsa.gov",
 			Groups:           []string{},
 			ProxyGroupIds:    []string{},
-			ExpectedValid:    false,
+			ExpectedValid:    true,
 			ExpectedInGroups: []string{},
 			ExpectError:      nil,
 		},

--- a/internal/proxy/providers/sso_test.go
+++ b/internal/proxy/providers/sso_test.go
@@ -319,7 +319,7 @@ func TestSSOProviderValidateSessionState(t *testing.T) {
 			ProviderResponse: http.StatusOK,
 			Groups:           []string{},
 			ProxyGroupIds:    []string{},
-			ExpectedValid:    false,
+			ExpectedValid:    true,
 		},
 		{
 			Name: "invalid when response is is not 200",


### PR DESCRIPTION
## Problem
When certain TTL's expire we revalidate or refresh the session (e.g. https://github.com/buzzfeed/sso/blob/master/internal/proxy/oauthproxy.go#L759-L764), which then ends up directly calling the `ValidateGroup` provider method (https://github.com/buzzfeed/sso/blob/master/internal/proxy/providers/sso.go#L381).

**If we're not using the validator abstractions, and group validation isn't being utilised**, then this causes a `403` with `user is no longer in valid groups` to be returned, requiring the user to refresh the page to progress further.

## Solution

The logic within `ValidateGroup` to return a success when an empty slice of groups is passed in was removed during some refactoring as, when using 'validator' abstractions this was deemed bad behaviour**, but until we stop calling `ValidateGroup` directly and use those abstractions _everywhere_ we need to maintain this behaviour.

https://github.com/buzzfeed/sso/pull/275 fixes this in a more permanent, stable fashion by replacing any remaining direct calls to `ValidateGroup` with calls to the validator abstractions, however until that is merged this is one possible temporary fix. 


## Notes

**This was deemed bad behaviour because if the group validator is the _only_ validator in use (and not email domains or addresses), then allowing `ValidateGroup` to return successful if an empty list of groups is passed becomes a loophole to allow the defining of no validators, something which we explicitly prevent (https://github.com/buzzfeed/sso/blob/master/internal/proxy/options.go#L205-L213)
