### PR TITLE
sso_proxy: allow empty slice of groups

### DIFF
--- a/internal/proxy/providers/sso.go
+++ b/internal/proxy/providers/sso.go
@@ -181,7 +181,7 @@ func (p *SSOProvider) ValidateGroup(email string, allowedGroups []string, access
 
 	logger.WithUser(email).WithAllowedGroups(allowedGroups).Info("validating groups")
 	inGroups := []string{}
-	if len(allowedGroups) == 0 {
+	if len(allowedGroups) == 0 || len(allowedGroups) == 1 && allowedGroups[0] == "*" {
 		return inGroups, true, nil
 	}
 

--- a/internal/proxy/providers/sso.go
+++ b/internal/proxy/providers/sso.go
@@ -181,6 +181,9 @@ func (p *SSOProvider) ValidateGroup(email string, allowedGroups []string, access
 
 	logger.WithUser(email).WithAllowedGroups(allowedGroups).Info("validating groups")
 	inGroups := []string{}
+	if len(allowedGroups) == 0 {
+		return inGroups, true, nil
+	}
 
 	userGroups, err := p.UserGroups(email, allowedGroups, accessToken)
 	if err != nil {

--- a/internal/proxy/providers/sso_test.go
+++ b/internal/proxy/providers/sso_test.go
@@ -144,11 +144,11 @@ func TestSSOProviderGroups(t *testing.T) {
 		ProfileStatus    int
 	}{
 		{
-			Name:             "invalid when no group id set",
+			Name:             "valid when no group id set",
 			Email:            "michael.bland@gsa.gov",
 			Groups:           []string{},
 			ProxyGroupIds:    []string{},
-			ExpectedValid:    false,
+			ExpectedValid:    true,
 			ExpectedInGroups: []string{},
 			ExpectError:      nil,
 		},
@@ -311,7 +311,7 @@ func TestSSOProviderValidateSessionState(t *testing.T) {
 		ExpectedValid    bool
 	}{
 		{
-			Name: "invalid when no group id set",
+			Name: "valid when no group id set",
 			SessionState: &sessions.SessionState{
 				AccessToken: "abc",
 				Email:       "michael.bland@gsa.gov",
@@ -319,7 +319,7 @@ func TestSSOProviderValidateSessionState(t *testing.T) {
 			ProviderResponse: http.StatusOK,
 			Groups:           []string{},
 			ProxyGroupIds:    []string{},
-			ExpectedValid:    false,
+			ExpectedValid:    true,
 		},
 		{
 			Name: "invalid when response is is not 200",

--- a/internal/proxy/providers/sso_test.go
+++ b/internal/proxy/providers/sso_test.go
@@ -153,6 +153,15 @@ func TestSSOProviderGroups(t *testing.T) {
 			ExpectError:      nil,
 		},
 		{
+			Name:             "valid when group list consists of a single wildcard",
+			Email:            "michael.bland@gsa.gov",
+			Groups:           []string{},
+			ProxyGroupIds:    []string{"*"},
+			ExpectedValid:    true,
+			ExpectedInGroups: []string{},
+			ExpectError:      nil,
+		},
+		{
 			Name:             "valid when the group id exists",
 			Email:            "michael.bland@gsa.gov",
 			Groups:           []string{"user-in-this-group", "random-group"},
@@ -319,6 +328,17 @@ func TestSSOProviderValidateSessionState(t *testing.T) {
 			ProviderResponse: http.StatusOK,
 			Groups:           []string{},
 			ProxyGroupIds:    []string{},
+			ExpectedValid:    true,
+		},
+		{
+			Name: "valid when group list consists of single wildcard",
+			SessionState: &sessions.SessionState{
+				AccessToken: "abc",
+				Email:       "michael.bland@gsa.gov",
+			},
+			ProviderResponse: http.StatusOK,
+			Groups:           []string{},
+			ProxyGroupIds:    []string{"*"},
 			ExpectedValid:    true,
 		},
 		{


### PR DESCRIPTION
## Problem
See https://github.com/buzzfeed/sso/pull/286
## Solution
This implements the initial fix described in https://github.com/buzzfeed/sso/pull/286. I think there may be a couple extra edge cases we need to cover in that pull request, so I've pulled out the fix here so it can be applied separately.
