### PR TITLE
sso_auth: make `provider_*_okta_server` optional

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -102,7 +102,7 @@ Notes:
 - `DEFAULT_PROVIDER_SLUG` tells **sso** to use the Okta provider by default
 
 - **If you are not using the default Okta authorization server** you will also
-  need to add `PROVIDER_OKTAQUICKSTART_SERVER_ID=<okta auth server ID>` to the
+  need to add `PROVIDER_OKTAQUICKSTART_OKTA_SERVER=<okta auth server ID>` to the
   above file.
 
 This `env` file will be used to configure `sso-auth` in the example deployment

--- a/internal/auth/configuration.go
+++ b/internal/auth/configuration.go
@@ -281,10 +281,6 @@ func (opc OktaProviderConfig) Validate() error {
 		return xerrors.New("no okta.url is configured")
 	}
 
-	if opc.ServerID == "" {
-		return xerrors.New("no okta.server is configured")
-	}
-
 	return nil
 }
 

--- a/internal/auth/providers/okta.go
+++ b/internal/auth/providers/okta.go
@@ -33,13 +33,12 @@ type GetUserProfileResponse struct {
 
 // NewOktaProvider returns a new OktaProvider and sets the provider url endpoints.
 func NewOktaProvider(p *ProviderData, OrgURL, providerServerID string) (*OktaProvider, error) {
-	if OrgURL != "" || providerServerID != "" {
-		if OrgURL == "" {
-			return nil, errors.New("missing setting: okta_org_url")
-		}
-		if providerServerID == "" {
-			return nil, errors.New("missing setting: provider_server_id")
-		}
+	if OrgURL == "" {
+		return nil, errors.New("missing setting: okta_org_url")
+	}
+	urlprefix := "/oauth2"
+	if providerServerID != "" {
+		urlprefix = fmt.Sprintf("/oauth2/%s", providerServerID)
 	}
 
 	p.ProviderName = "Okta"
@@ -49,7 +48,7 @@ func NewOktaProvider(p *ProviderData, OrgURL, providerServerID string) (*OktaPro
 	p.SignInURL = &url.URL{
 		Scheme: scheme,
 		Host:   OrgURL,
-		Path:   fmt.Sprintf("/oauth2/%s/v1/authorize", providerServerID),
+		Path:   fmt.Sprintf("%s/v1/authorize", urlprefix),
 	}
 	// to get a refresh token. see https://developer.okta.com/authentication-guide/tokens/refreshing-tokens/
 
@@ -57,26 +56,26 @@ func NewOktaProvider(p *ProviderData, OrgURL, providerServerID string) (*OktaPro
 	p.RedeemURL = &url.URL{
 		Scheme: scheme,
 		Host:   OrgURL,
-		Path:   fmt.Sprintf("/oauth2/%s/v1/token", providerServerID),
+		Path:   fmt.Sprintf("%s/v1/token", urlprefix),
 	}
 
 	// revokes an access or refresh token
 	p.RevokeURL = &url.URL{
 		Scheme: scheme,
 		Host:   OrgURL,
-		Path:   fmt.Sprintf("/oauth2/%s/v1/revoke", providerServerID),
+		Path:   fmt.Sprintf("%s/v1/revoke", urlprefix),
 	}
 	// takes an access token and returns claims for the currently logged-in user
 	p.ProfileURL = &url.URL{
 		Scheme: scheme,
 		Host:   OrgURL,
-		Path:   fmt.Sprintf("/oauth2/%s/v1/userinfo", providerServerID),
+		Path:   fmt.Sprintf("%s/v1/userinfo", urlprefix),
 	}
 	// takes token as a URL query and returns active/inactive, and further info if active.
 	p.ValidateURL = &url.URL{
 		Scheme: scheme,
 		Host:   OrgURL,
-		Path:   fmt.Sprintf("/oauth2/%s/v1/introspect", providerServerID),
+		Path:   fmt.Sprintf("%s/v1/introspect", urlprefix),
 	}
 	if p.Scope == "" {
 		// https://developer.okta.com/docs/api/resources/oidc/#scopes


### PR DESCRIPTION
## Problem

[Quickstart](https://github.com/buzzfeed/sso/blob/master/docs/quickstart.md#okta) (and testing in practice) seems to indicate that PROVIDER_*_OKTA_SERVER should be optional, if you wish to use the default okta authorization server.

> If you are not using the default Okta authorization server you will also need to add PROVIDER_OKTAQUICKSTART_SERVER_ID=<okta auth server ID> to the above file.

## Solution

Make it optional!

## Notes
