### PR TITLE
Updated dockerfile to golang 1.14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 defaults: &defaults
   docker:
-    - image: circleci/golang:1.12
+    - image: circleci/golang:1.14
   working_directory: /go/src/github.com/buzzfeed/sso
 
 attach_workspace: &attach_workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #
 # install golang dependencies & build binaries
 # =============================================================================
-FROM golang:1.12 AS build
+FROM golang:1.14 AS build
 
 ENV GOFLAGS='-ldflags=-s -ldflags=-w'
 ENV CGO_ENABLED=0
@@ -23,6 +23,7 @@ RUN cd cmd/sso-proxy && go build -mod=readonly -o /bin/sso-proxy
 # add static assets and copy binaries from build stage
 # =============================================================================
 FROM debian:stable-slim
+ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y ca-certificates curl && rm -rf /var/lib/apt/lists/* \
     && groupadd -r sso && useradd -r -g sso sso
 WORKDIR /sso


### PR DESCRIPTION
## Problem

Golang 1.12 is now EOL.
Can't locate Term/ReadLine.pm in @INC in docker build.

## Solution

Update dockerfile to use golang:1.14 as build image.
Added "ENV DEBIAN_FRONTEND noninteractive" to dockerfile

## Notes

Other pertinent information. Examples: a walkthrough of how the solution might work, why this solution is optimal compared to other possible solutions, or further TODOs beyond this PR.
