### PR TITLE
sso_*: update to Go 1.14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 defaults: &defaults
   docker:
-    - image: circleci/golang:1.12
+    - image: circleci/golang:1.14
   working_directory: /go/src/github.com/buzzfeed/sso
 
 attach_workspace: &attach_workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #
 # install golang dependencies & build binaries
 # =============================================================================
-FROM golang:1.12 AS build
+FROM golang:1.14 AS build
 
 ENV GOFLAGS='-ldflags=-s -ldflags=-w'
 ENV CGO_ENABLED=0

--- a/go.mod
+++ b/go.mod
@@ -23,3 +23,5 @@ require (
 	google.golang.org/api v0.5.0
 	gopkg.in/yaml.v2 v2.2.2
 )
+
+go 1.14

--- a/internal/proxy/options_test.go
+++ b/internal/proxy/options_test.go
@@ -118,7 +118,7 @@ func TestProviderURLValidation(t *testing.T) {
 			name:              "invalid url rejected",
 			providerURLString: "%ZZZ",
 			expectedError: errorMsg([]string{
-				`invalid value for provider-url: parse %ZZZ: invalid URL escape "%ZZ"`,
+				`invalid value for provider-url: parse "%ZZZ": invalid URL escape "%ZZ"`,
 			}),
 		},
 	}


### PR DESCRIPTION
Updates SSO to Go 1.14.

#### Test changes
- `internal/proxy/options_test.go`:  quoted error as per 
https://golang.org/doc/go1.14#net/url
> When parsing of a URL fails (for example by Parse or ParseRequestURI), the resulting Error message will now quote the unparsable URL. This provides clearer structure and consistency with other parsing errors.
