### PR TITLE
sso_proxy: document provider slug configs

### DIFF
--- a/docs/sso_config.md
+++ b/docs/sso_config.md
@@ -35,11 +35,12 @@ For example, the following config would have the following environment variables
     * **allowed groups** optional list of authorized google groups that can access the service. If not specified, anyone within an email domain is allowed to access the service. *Note*: We do not support nested group authentication at this time. Groups must be made up of email addresses associated with individual's accounts. See [#133](https://github.com/buzzfeed/sso/issues/133).
     * **allowed_email_domains** optional list of authorized email domains that can access the service.
     * **allowed_email_addresses** optional list of authorized email addresses that can access the service.
-    * **skip_auth_regex** skips authentication for paths matching these regular expressions. NOTE: Use with extreme caution.
+    * **flush_interval** sets an interval to periodically flush the buffered response to the client. If specified, SSO Proxy will not timeout requests to this upstream and will stream the response to the client. NOTE: Use with extreme caution.
     * **header_overrides** overrides any heads set either by SSO proxy itself or upstream applications. Useful for modifying browser security headers.
     * **inject_request_headers** adds headers to the request before the request is sent to the proxied service.  Useful for adding basic auth headers if needed.
+    * **provider_slug** determines which identity provider this upstream will use. This provider must first be configured within `sso_auth`.
+    * **skip_auth_regex** skips authentication for paths matching these regular expressions. NOTE: Use with extreme caution.
     * **timeout** sets the amount of time that SSO Proxy will wait for the upstream to complete its request.
-    * **flush_interval** sets an interval to periodically flush the buffered response to the client. If specified, SSO Proxy will not timeout requests to this upstream and will stream the response to the client. NOTE: Use with extreme caution.
   * **extra_routes** allows services to specify multiple routes. These route can includes the *from*, *to*, *type*, and *options* fields defined above and inherit any configuration
 from their parent routing config if not specified here (e.g. *options*).
 * **cluster name <identifier>** are cluster-specific settings. Any configuration specified in the default field can be override here with cluster specific configuration.

--- a/internal/proxy/options.go
+++ b/internal/proxy/options.go
@@ -27,6 +27,7 @@ import (
 // DefaultAllowedEmailDomains - csv list of emails with the specified domain to authenticate. Use * to authenticate any email
 // DefaultAllowedEmailAddresses - []string - authenticate emails with the specified email address (may be given multiple times). Use * to authenticate any email
 // DefaultAllowedGroups - csv list of default allowed groups that are applied to authorize access to upstreams. Will be overridden by groups specified in upstream configs.
+// DefaultProviderSlug - the provider that upstreams should use by default. Provider must exist within `sso_auth`. ie: "google"
 // ClientID - the OAuth Client ID: ie: "123456.apps.googleusercontent.com"
 // ClientSecret - The OAuth Client Secret
 // DefaultUpstreamTimeout - the default time period to wait for a response from an upstream


### PR DESCRIPTION
## Problem

Some documentation for the upstream configuration option `provider_slug`, and the global `sso_proxy` 
`DefaultProviderSlug` option is missing

## Solution
Add in the missing documentation.

