### PR TITLE
sso-proxy: command line tool to generate request signatures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN go mod download
 COPY . .
 RUN cd cmd/sso-auth && go build -mod=readonly -o /bin/sso-auth
 RUN cd cmd/sso-proxy && go build -mod=readonly -o /bin/sso-proxy
+RUN cd cmd/sso-proxy/generate-request-signature && go build -mod=readonly -o /bin/sso-generate-request-signature
 
 # =============================================================================
 # final stage

--- a/cmd/sso-proxy/generate-request-signature/generate_request_signature.go
+++ b/cmd/sso-proxy/generate-request-signature/generate_request_signature.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/buzzfeed/sso/internal/pkg/logging"
+	"github.com/buzzfeed/sso/internal/proxy"
+)
+
+// Name of the header used to transmit the signature computed for the request.
+var signatureHeader = "Sso-Signature"
+var signingKeyHeader = "kid"
+
+func main() {
+	logger := logging.NewLogEntry()
+	var requestSigner *proxy.RequestSigner
+
+	config, err := proxy.LoadConfig()
+	if err != nil {
+		logger.Error(err, "error loading in config from env vars")
+		os.Exit(1)
+	}
+
+	urlPtr := flag.String("url", "", "URL of request to sign")
+	methodPtr := flag.String("method", "GET", "Method of request to sign")
+	bodyPtr := flag.String("body", "", "Body of request to sign")
+
+	err = config.Validate()
+	if err != nil {
+		logger.Error(err, "error validating config")
+		os.Exit(1)
+	}
+
+	requestSigner, err = proxy.NewRequestSigner(config.RequestSignerConfig.Key)
+	if err != nil {
+		logger.Error(err, "error creating request signer")
+		os.Exit(1)
+	}
+
+	flag.Parse()
+	args := flag.Args()
+
+	requestBody := *strings.NewReader(*bodyPtr)
+
+	req, err := http.NewRequest(*methodPtr, *urlPtr, &requestBody)
+	if err != nil {
+		logger.Error(err, "error creating request")
+		os.Exit(1)
+	}
+
+	for _, h := range args {
+		hKv := strings.Split(h, ":")
+		req.Header.Set(hKv[0], hKv[1])
+	}
+
+	err = requestSigner.Sign(req)
+	if err != nil {
+		logger.Error(err, "error signing request")
+		os.Exit(1)
+	}
+
+	signature := req.Header.Get(signatureHeader)
+	keyHeader := req.Header.Get(signingKeyHeader)
+
+	fmt.Printf("URL: %v\n", *urlPtr)
+	fmt.Printf("method: %v\n", *methodPtr)
+	fmt.Printf("body: %v\n", *bodyPtr)
+	fmt.Printf("headers: %v\n", req.Header)
+	fmt.Println("==================================================================")
+
+	fmt.Printf("signature: %v\n", signature)
+	fmt.Printf("keyHeader: %v\n", keyHeader)
+}

--- a/docs/generate_request_signature.md
+++ b/docs/generate_request_signature.md
@@ -1,0 +1,11 @@
+## sso_proxy/generate-request-signature
+`sso-generate-request-signature` is a command-line tool that is provided alongside `sso_proxy` to facilitate upstream testing of SSO's proxied request signatures, or of libraries that attempt to validate signatures. Note that running `sso-generate-request-signature` requires some of the same configuration to be in place as running `sso-proxy` would, i.e. a `REQUESTSIGNER_KEY` environment variable. Assuming that exists, the tool can be run with three optional flags, followed by as many request headers as desired in `<name>:<value>` format:
+
+- `-url`: the path of the URL of the request to calculate the signature on (default: "")
+- `-method`: the method of the request (default: "GET") (note: the method is not used in the signature calculation)
+- `-body`: for PUT or POST requests, a string representing the body of the request to calculate a signature on (default: "")
+
+### examples
+`sso-generate-request-signature -url "/foo" -method "POST" -body "{}" x-header-1:bar x-header-2:baz`
+
+`sso-generate-request-signature -url "/bar"`


### PR DESCRIPTION
## Problem
For testing signature validation code in other places, it's nice to be able to easily generate signatures. The prior way of doing this involved setting up a test service, making a request to it, and inspecting the request headers between SSO and the upstream to get the signature.

## Solution
Make a little command line tool within `sso-proxy` that takes URL, body, and headers to generate a request signature using the `request-signer`.

