### PR TITLE
sso_auth: use ProxyFromEnvironment in http Transport

### DIFF
--- a/internal/auth/providers/http_client.go
+++ b/internal/auth/providers/http_client.go
@@ -9,6 +9,7 @@ import (
 var httpClient = &http.Client{
 	Timeout: time.Second * 5,
 	Transport: &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
 		Dial: (&net.Dialer{
 			Timeout: 2 * time.Second,
 		}).Dial,

--- a/internal/proxy/providers/http_client.go
+++ b/internal/proxy/providers/http_client.go
@@ -9,6 +9,7 @@ import (
 var httpClient = &http.Client{
 	Timeout: time.Second * 5,
 	Transport: &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
 		Dial: (&net.Dialer{
 			Timeout: 2 * time.Second,
 		}).Dial,


### PR DESCRIPTION
## Problem

As described in https://github.com/buzzfeed/sso/issues/305, some HTTP clients used in `sso_auth` and `sso_proxy` don't allow for use of `HTTP_PROXY` environment variables -- meaning traffic can't be passed through a proxy if desired.

## Solution
Make use of the [http.ProxyFromEnvironment](https://golang.org/src/net/http/transport.go?s=16634:16691#L427) method, which allows for usage of these environment variables.

We already make use of this in one HTTP client within `sso_proxy` here: https://github.com/buzzfeed/sso/blob/03e1259e8ce040a5b3937ce684598aa1f9bb980b/internal/proxy/reverse_proxy.go#L53
