### PR TITLE
sso_*: rename 'options' package to 'validators'

### DIFF
--- a/internal/auth/authenticator.go
+++ b/internal/auth/authenticator.go
@@ -12,9 +12,9 @@ import (
 	"github.com/buzzfeed/sso/internal/auth/providers"
 	"github.com/buzzfeed/sso/internal/pkg/aead"
 	log "github.com/buzzfeed/sso/internal/pkg/logging"
-	"github.com/buzzfeed/sso/internal/pkg/options"
 	"github.com/buzzfeed/sso/internal/pkg/sessions"
 	"github.com/buzzfeed/sso/internal/pkg/templates"
+	"github.com/buzzfeed/sso/internal/pkg/validators"
 
 	"github.com/datadog/datadog-go/statsd"
 	"github.com/gorilla/mux"
@@ -22,7 +22,7 @@ import (
 
 // Authenticator stores all the information associated with proxying the request.
 type Authenticator struct {
-	Validators       []options.Validator
+	Validators       []validators.Validator
 	EmailDomains     []string
 	ProxyRootDomains []string
 	Host             string
@@ -228,7 +228,7 @@ func (p *Authenticator) authenticate(rw http.ResponseWriter, req *http.Request) 
 		}
 	}
 
-	errors := options.RunValidators(p.Validators, session)
+	errors := validators.RunValidators(p.Validators, session)
 	if len(errors) == len(p.Validators) {
 		logger.WithUser(session.Email).Info(
 			fmt.Sprintf("permission denied: unauthorized: %q", errors))
@@ -584,7 +584,7 @@ func (p *Authenticator) getOAuthCallback(rw http.ResponseWriter, req *http.Reque
 	// - for p.Validator see validator.go#newValidatorImpl for more info
 	// - for p.provider.ValidateGroup see providers/google.go#ValidateGroup for more info
 
-	errors := options.RunValidators(p.Validators, session)
+	errors := validators.RunValidators(p.Validators, session)
 	if len(errors) == len(p.Validators) {
 		tags := append(tags, "error:invalid_email")
 		p.StatsdClient.Incr("application_error", tags, 1.0)

--- a/internal/auth/authenticator_test.go
+++ b/internal/auth/authenticator_test.go
@@ -17,10 +17,10 @@ import (
 
 	"github.com/buzzfeed/sso/internal/auth/providers"
 	"github.com/buzzfeed/sso/internal/pkg/aead"
-	"github.com/buzzfeed/sso/internal/pkg/options"
 	"github.com/buzzfeed/sso/internal/pkg/sessions"
 	"github.com/buzzfeed/sso/internal/pkg/templates"
 	"github.com/buzzfeed/sso/internal/pkg/testutil"
+	"github.com/buzzfeed/sso/internal/pkg/validators"
 )
 
 func init() {
@@ -418,7 +418,7 @@ func TestSignIn(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			config := testConfiguration(t)
 			auth, err := NewAuthenticator(config,
-				SetValidators([]options.Validator{options.NewMockValidator(tc.validEmail)}),
+				SetValidators([]validators.Validator{validators.NewMockValidator(tc.validEmail)}),
 				setMockSessionStore(tc.mockSessionStore),
 				setMockTempl(),
 				setMockRedirectURL(),
@@ -565,7 +565,7 @@ func TestSignOutPage(t *testing.T) {
 			provider.RevokeError = tc.RevokeError
 
 			p, _ := NewAuthenticator(config,
-				SetValidators([]options.Validator{options.NewMockValidator(true)}),
+				SetValidators([]validators.Validator{validators.NewMockValidator(true)}),
 				setMockSessionStore(tc.mockSessionStore),
 				setMockTempl(),
 				setTestProvider(provider),
@@ -942,7 +942,7 @@ func TestGetProfile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			config := testConfiguration(t)
 			p, _ := NewAuthenticator(config,
-				SetValidators([]options.Validator{options.NewMockValidator(true)}),
+				SetValidators([]validators.Validator{validators.NewMockValidator(true)}),
 			)
 			u, _ := url.Parse("http://example.com")
 			testProvider := providers.NewTestProvider(u)
@@ -1044,7 +1044,7 @@ func TestRedeemCode(t *testing.T) {
 			config := testConfiguration(t)
 
 			proxy, _ := NewAuthenticator(config,
-				SetValidators([]options.Validator{options.NewMockValidator(true)}),
+				SetValidators([]validators.Validator{validators.NewMockValidator(true)}),
 			)
 
 			testURL, err := url.Parse("example.com")
@@ -1433,7 +1433,7 @@ func TestOAuthCallback(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			config := testConfiguration(t)
 			proxy, _ := NewAuthenticator(config,
-				SetValidators([]options.Validator{options.NewMockValidator(tc.validEmail)}),
+				SetValidators([]validators.Validator{validators.NewMockValidator(tc.validEmail)}),
 				setMockCSRFStore(tc.csrfResp),
 				setMockSessionStore(tc.sessionStore),
 			)
@@ -1554,7 +1554,7 @@ func TestOAuthStart(t *testing.T) {
 			provider := providers.NewTestProvider(nil)
 			proxy, _ := NewAuthenticator(config,
 				setTestProvider(provider),
-				SetValidators([]options.Validator{options.NewMockValidator(true)}),
+				SetValidators([]validators.Validator{validators.NewMockValidator(true)}),
 				setMockRedirectURL(),
 				setMockCSRFStore(&sessions.MockCSRFStore{}),
 			)

--- a/internal/auth/mux.go
+++ b/internal/auth/mux.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/buzzfeed/sso/internal/pkg/hostmux"
 	log "github.com/buzzfeed/sso/internal/pkg/logging"
-	"github.com/buzzfeed/sso/internal/pkg/options"
+	"github.com/buzzfeed/sso/internal/pkg/validators"
 
 	"github.com/datadog/datadog-go/statsd"
 	"github.com/gorilla/mux"
@@ -19,11 +19,11 @@ type AuthenticatorMux struct {
 
 func NewAuthenticatorMux(config Configuration, statsdClient *statsd.Client) (*AuthenticatorMux, error) {
 	logger := log.NewLogEntry()
-	validators := []options.Validator{}
+	v := []validators.Validator{}
 	if len(config.AuthorizeConfig.EmailConfig.Addresses) != 0 {
-		validators = append(validators, options.NewEmailAddressValidator(config.AuthorizeConfig.EmailConfig.Addresses))
+		v = append(v, validators.NewEmailAddressValidator(config.AuthorizeConfig.EmailConfig.Addresses))
 	} else {
-		validators = append(validators, options.NewEmailDomainValidator(config.AuthorizeConfig.EmailConfig.Domains))
+		v = append(v, validators.NewEmailDomainValidator(config.AuthorizeConfig.EmailConfig.Domains))
 	}
 
 	authenticators := []*Authenticator{}
@@ -39,7 +39,7 @@ func NewAuthenticatorMux(config Configuration, statsdClient *statsd.Client) (*Au
 
 		idpSlug := idp.Data().ProviderSlug
 		authenticator, err := NewAuthenticator(config,
-			SetValidators(validators),
+			SetValidators(v),
 			SetProvider(idp),
 			SetCookieStore(config.SessionConfig, idpSlug),
 			SetStatsdClient(statsdClient),

--- a/internal/auth/options.go
+++ b/internal/auth/options.go
@@ -9,8 +9,8 @@ import (
 	"github.com/buzzfeed/sso/internal/auth/providers"
 	"github.com/buzzfeed/sso/internal/pkg/aead"
 	"github.com/buzzfeed/sso/internal/pkg/groups"
-	"github.com/buzzfeed/sso/internal/pkg/options"
 	"github.com/buzzfeed/sso/internal/pkg/sessions"
+	"github.com/buzzfeed/sso/internal/pkg/validators"
 
 	"github.com/datadog/datadog-go/statsd"
 )
@@ -115,7 +115,7 @@ func SetRedirectURL(serverConfig ServerConfig, slug string) func(*Authenticator)
 }
 
 // SetValidator sets the email validator
-func SetValidators(validators []options.Validator) func(*Authenticator) error {
+func SetValidators(validators []validators.Validator) func(*Authenticator) error {
 	return func(a *Authenticator) error {
 		a.Validators = validators
 		return nil

--- a/internal/pkg/validators/email_address_validator.go
+++ b/internal/pkg/validators/email_address_validator.go
@@ -1,4 +1,4 @@
-package options
+package validators
 
 import (
 	"errors"

--- a/internal/pkg/validators/email_address_validator_test.go
+++ b/internal/pkg/validators/email_address_validator_test.go
@@ -1,4 +1,4 @@
-package options
+package validators
 
 import (
 	"testing"

--- a/internal/pkg/validators/email_domain_validator.go
+++ b/internal/pkg/validators/email_domain_validator.go
@@ -1,4 +1,4 @@
-package options
+package validators
 
 import (
 	"errors"

--- a/internal/pkg/validators/email_domain_validator_test.go
+++ b/internal/pkg/validators/email_domain_validator_test.go
@@ -1,4 +1,4 @@
-package options
+package validators
 
 import (
 	"testing"

--- a/internal/pkg/validators/email_group_validator.go
+++ b/internal/pkg/validators/email_group_validator.go
@@ -1,4 +1,4 @@
-package options
+package validators
 
 import (
 	"errors"

--- a/internal/pkg/validators/mock_validator.go
+++ b/internal/pkg/validators/mock_validator.go
@@ -1,4 +1,4 @@
-package options
+package validators
 
 import (
 	"errors"

--- a/internal/pkg/validators/validators.go
+++ b/internal/pkg/validators/validators.go
@@ -1,4 +1,4 @@
-package options
+package validators
 
 import (
 	"errors"

--- a/internal/proxy/oauthproxy_test.go
+++ b/internal/proxy/oauthproxy_test.go
@@ -21,9 +21,9 @@ import (
 	"github.com/mccutchen/go-httpbin/httpbin"
 
 	"github.com/buzzfeed/sso/internal/pkg/aead"
-	"github.com/buzzfeed/sso/internal/pkg/options"
 	"github.com/buzzfeed/sso/internal/pkg/sessions"
 	"github.com/buzzfeed/sso/internal/pkg/testutil"
+	"github.com/buzzfeed/sso/internal/pkg/validators"
 	"github.com/buzzfeed/sso/internal/proxy/providers"
 )
 
@@ -121,7 +121,7 @@ func testNewOAuthProxy(t *testing.T, optFuncs ...func(*OAuthProxy) error) (*OAut
 	statsdClient, _ := statsd.New("127.0.0.1:8125")
 
 	standardOptFuncs := []func(*OAuthProxy) error{
-		SetValidators([]options.Validator{options.NewMockValidator(true)}),
+		SetValidators([]validators.Validator{validators.NewMockValidator(true)}),
 		SetProvider(provider),
 		setSessionStore(&sessions.MockSessionStore{Session: testSession()}),
 		SetUpstreamConfig(upstreamConfig),
@@ -279,7 +279,7 @@ func TestAuthOnlyEndpoint(t *testing.T) {
 
 			proxy, close := testNewOAuthProxy(t,
 				setSessionStore(tc.sessionStore),
-				SetValidators([]options.Validator{options.NewMockValidator(tc.validEmail)}),
+				SetValidators([]validators.Validator{validators.NewMockValidator(tc.validEmail)}),
 				SetProvider(tp),
 			)
 			defer close()

--- a/internal/proxy/options.go
+++ b/internal/proxy/options.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 
 	log "github.com/buzzfeed/sso/internal/pkg/logging"
-	"github.com/buzzfeed/sso/internal/pkg/options"
 	"github.com/buzzfeed/sso/internal/pkg/sessions"
+	"github.com/buzzfeed/sso/internal/pkg/validators"
 	"github.com/buzzfeed/sso/internal/proxy/providers"
 
 	"github.com/datadog/datadog-go/statsd"
@@ -95,7 +95,7 @@ func SetProxyHandler(handler http.Handler) func(*OAuthProxy) error {
 }
 
 // SetValidator sets the email validator as a functional option
-func SetValidators(validators []options.Validator) func(*OAuthProxy) error {
+func SetValidators(validators []validators.Validator) func(*OAuthProxy) error {
 	return func(op *OAuthProxy) error {
 		op.Validators = validators
 		return nil

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	"github.com/buzzfeed/sso/internal/pkg/hostmux"
-	"github.com/buzzfeed/sso/internal/pkg/options"
+	"github.com/buzzfeed/sso/internal/pkg/validators"
 	"github.com/datadog/datadog-go/statsd"
 )
 
@@ -45,17 +45,17 @@ func New(config Configuration, statsdClient *statsd.Client) (*SSOProxy, error) {
 			return nil, err
 		}
 
-		validators := []options.Validator{}
+		v := []validators.Validator{}
 		if len(upstreamConfig.AllowedEmailAddresses) != 0 {
-			validators = append(validators, options.NewEmailAddressValidator(upstreamConfig.AllowedEmailAddresses))
+			v = append(v, validators.NewEmailAddressValidator(upstreamConfig.AllowedEmailAddresses))
 		}
 
 		if len(upstreamConfig.AllowedEmailDomains) != 0 {
-			validators = append(validators, options.NewEmailDomainValidator(upstreamConfig.AllowedEmailDomains))
+			v = append(v, validators.NewEmailDomainValidator(upstreamConfig.AllowedEmailDomains))
 		}
 
 		if len(upstreamConfig.AllowedGroups) != 0 {
-			validators = append(validators, options.NewEmailGroupValidator(provider, upstreamConfig.AllowedGroups))
+			v = append(v, validators.NewEmailGroupValidator(provider, upstreamConfig.AllowedGroups))
 		}
 
 		optFuncs = append(optFuncs,
@@ -64,7 +64,7 @@ func New(config Configuration, statsdClient *statsd.Client) (*SSOProxy, error) {
 			SetUpstreamConfig(upstreamConfig),
 			SetProxyHandler(handler),
 			SetStatsdClient(statsdClient),
-			SetValidators(validators),
+			SetValidators(v),
 		)
 
 		oauthproxy, err := NewOAuthProxy(config.SessionConfig, optFuncs...)


### PR DESCRIPTION
## Problem
In `internal/pkg/options` we offer a set of tools to help validate sessions. The name of the package, 'options', doesn't fit its responsibility very well, which can contribute to unnecessary confusion while reading through the code.
## Solution
Separated out from some other cleanups, rename the `options` package to `validators`, and adjust any references to it.

## Notes

Other pertinent information. Examples: a walkthrough of how the solution might work, why this solution is optimal compared to other possible solutions, or further TODOs beyond this PR.
