### PR TITLE
quickstart - rename CLUSTER to UPSTREAM_CLUSTER

### DIFF
--- a/quickstart/docker-compose.yml
+++ b/quickstart/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       - SESSION_COOKIE_SECURE=false
 
       # TODO: these config values should probably have defaults
-      - CLUSTER=dev
+      - UPSTREAM_CLUSTER=dev
       - METRICS_STATSD_HOST=127.0.0.1
       - METRICS_STATSD_PORT=8125
 
@@ -103,7 +103,6 @@ services:
       - SESSION_COOKIE_SECURE=false
 
       # TODO: these config values should probably have defaults
-      - CLUSTER=dev
       - METRICS_STATSD_HOST=127.0.0.1
       - METRICS_STATSD_PORT=8125
 


### PR DESCRIPTION
## Problem

quickstart is not fully updated with the new variables name introduced with the v3.0.0

## Solution

rename CLUSTER to UPSTREAM_CLUSTER in sso-proxy
remove CLUSTER from sso-auth. it looks like is not used anymore (https://github.com/buzzfeed/sso/blob/main/internal/auth/configuration.go)

