### PR TITLE
sessions pkg: minor refactors

### DIFF
--- a/internal/pkg/sessions/session_state.go
+++ b/internal/pkg/sessions/session_state.go
@@ -53,6 +53,14 @@ func isExpired(t time.Time) bool {
 	return false
 }
 
+// IsWithinGracePeriod returns true if the session is still within the grace period
+func (s *SessionState) IsWithinGracePeriod(gracePeriodTTL time.Duration) bool {
+	if s.GracePeriodStart.IsZero() {
+		s.GracePeriodStart = time.Now()
+	}
+	return s.GracePeriodStart.Add(gracePeriodTTL).After(time.Now())
+}
+
 // MarshalSession marshals the session state as JSON, encrypts the JSON using the
 // given cipher, and base64-encodes the result
 func MarshalSession(s *SessionState, c aead.Cipher) (string, error) {

--- a/internal/pkg/sessions/session_state_test.go
+++ b/internal/pkg/sessions/session_state_test.go
@@ -55,20 +55,29 @@ func TestSessionStateExpirations(t *testing.T) {
 		LifetimeDeadline: time.Now().Add(-1 * time.Hour),
 		RefreshDeadline:  time.Now().Add(-1 * time.Hour),
 		ValidDeadline:    time.Now().Add(-1 * time.Minute),
+		GracePeriodStart: time.Now().Add(-2 * time.Minute),
 
 		Email: "user@domain.com",
 		User:  "user",
 	}
 
 	if !session.LifetimePeriodExpired() {
-		t.Errorf("expcted lifetime period to be expired")
+		t.Errorf("expected lifetime period to be expired")
 	}
 
 	if !session.RefreshPeriodExpired() {
-		t.Errorf("expcted lifetime period to be expired")
+		t.Errorf("expected lifetime period to be expired")
 	}
 
 	if !session.ValidationPeriodExpired() {
-		t.Errorf("expcted lifetime period to be expired")
+		t.Errorf("expected lifetime period to be expired")
+	}
+
+	if session.IsWithinGracePeriod(1 * time.Minute) {
+		t.Errorf("expected session to be outside of grace period")
+	}
+
+	if !session.IsWithinGracePeriod(3 * time.Minute) {
+		t.Errorf("expected session to be inside of grace period")
 	}
 }


### PR DESCRIPTION
## Problem
In an effort to reduce the scale of some other changes I'm trying to pull through, we make some small refactors here to `internal/proxy/providers/sso.go`.

## Solution
Included refactors are:
- Pull out the `withinGracePeriod` method within `internal/proxy/providers/sso.go` into a new method within the sessions package: `IsWithinGracePeriod`.
- Instead of calling a local `extendDeadline` function within `internal/proxy/providers/sso.go`, call the already existing sessions package `ExtendDeadline` method.
