### PR TITLE
sso: fixup for debian bullseye repo changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN cd cmd/sso-proxy/generate-request-signature && go build -mod=readonly -o /bi
 #
 # add static assets and copy binaries from build stage
 # =============================================================================
-FROM debian:stable-slim
+FROM debian:buster-slim
 RUN apt-get update && apt-get install -y ca-certificates curl && rm -rf /var/lib/apt/lists/* \
     && groupadd -r sso && useradd -r -g sso sso
 WORKDIR /sso


### PR DESCRIPTION
# Problem

`debian:stable-slim` is broken by a repo change but `debian:buster-slim` works

https://www.mail-archive.com/search?l=debian-user@lists.debian.org&q=subject:%22what%27s+wrong+with+my+%5C%22%5C%2Fetc%5C%2Fapt%5C%2Fsources.list%5C%22%5C%3F+Updating+from+such+a+repository+can%27t+be+done+securely%2C+and+is+therefore+disabled+by+default%22&o=newest&f=1

# Solution

5.1.3. Changed security archive layout
For bullseye, the security suite is now named bullseye-security instead of codename/updates and users should adapt their APT source-list files accordingly when upgrading.

The security line in your APT configuration may look like:

deb https://deb.debian.org/debian-security bullseye-security main contrib
If your APT configuration also involves pinning or APT::Default-Release, it is likely to require adjustments as the codename of the security archive no longer matches that of the regular archive. An example of a working APT::Default-Release line for bullseye looks like:

APT::Default-Release "/^bullseye(|-security|-updates)$/";
which takes advantage of the undocumented feature of APT that it supports regular expressions (inside /).

from: https://www.debian.org/releases/bullseye/amd64/release-notes/ch-information.en.html#upgrade-specific-issues

# Notes


_Please see http://go/pr-reviews in the engineering guide for tips on crafting a PR for review!_