### PR TITLE
sso_auth: configuration typo

### DIFF
--- a/internal/auth/configuration.go
+++ b/internal/auth/configuration.go
@@ -155,7 +155,7 @@ type Configuration struct {
 	AuthorizeConfig  AuthorizeConfig           `mapstructure:"authorize"`
 	SessionConfig    SessionConfig             `mapstructure:"session"`
 	ServerConfig     ServerConfig              `mapstructure:"server"`
-	MetricsConfig    MetricsConfig             `mapstructrue:"metrics"`
+	MetricsConfig    MetricsConfig             `mapstructure:"metrics"`
 	LoggingConfig    LoggingConfig             `mapstructure:"logging"`
 }
 


### PR DESCRIPTION
## Problem

A typo in `auth/configuration.yml` is preventing `METRICS_STATSD_*` environment variables from being registered, resulting in the default always being used.

## Solution

mapstruc**true** -> mapstruc**ture** 🥲
