### PR TITLE
Added version flag for sso-auth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ build: dist/sso-auth dist/sso-proxy
 dist/sso-auth:
 	mkdir -p dist
 	go generate ./...
+	echo $(version) > dist/.version.txt
 	go build -mod=readonly -o dist/sso-auth ./cmd/sso-auth
 
 dist/sso-proxy:


### PR DESCRIPTION
## Problem

Adds version flag for sso-auth. Closes #36 

## Solution

Using Flags std library and writing version from makefile to a hidden text file in dist folder. This approach allows us to provide the version only in Makefile.

`v3.0.0`
`Built with go1.17`

## Notes

