### PR TITLE
sessions pkg: omit domain attribute in session cookie

### DIFF
--- a/docs/sso_authenticator_config.md
+++ b/docs/sso_authenticator_config.md
@@ -11,7 +11,7 @@ Defaults for the below settings can be found here: https://github.com/buzzfeed/s
 ```
 SESSION_COOKIE_NAME     - string - name associated with the session cookie
 SESSION_COOKIE_SECRET   - string - seed string for secure cookies
-SESSION_COOKIE_DOMAIN   - string - cookie domain to force cookies to (ie: .yourcompany.com)*
+SESSION_COOKIE_DOMAIN   - string - cookie domain (and subdomains) to force cookies to (ie: .yourcompany.com)*
 SESSION_KEY             - string - seed string for secure auth codes
 SESSION_COOKIE_SECURE   - bool - set secure (HTTPS) cookie flag
 SESSION_COOKIE_HTTPONLY - bool - set 'httponly' cookie flag

--- a/docs/sso_authenticator_config.md
+++ b/docs/sso_authenticator_config.md
@@ -11,7 +11,9 @@ Defaults for the below settings can be found here: https://github.com/buzzfeed/s
 ```
 SESSION_COOKIE_NAME     - string - name associated with the session cookie
 SESSION_COOKIE_SECRET   - string - seed string for secure cookies
-SESSION_COOKIE_DOMAIN   - string - cookie domain (and subdomains) to force cookies to (ie: .yourcompany.com)*
+SESSION_COOKIE_DOMAIN   - string - cookie domain (and subdomains) to force cookies to (ie: .yourcompany.com). If this is set,
+cookies will be valid on subdomains too. To restrict to only the request's domain, leave this unset.
+Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent
 SESSION_KEY             - string - seed string for secure auth codes
 SESSION_COOKIE_SECURE   - bool - set secure (HTTPS) cookie flag
 SESSION_COOKIE_HTTPONLY - bool - set 'httponly' cookie flag

--- a/docs/sso_proxy_config.md
+++ b/docs/sso_proxy_config.md
@@ -11,7 +11,7 @@ Defaults for the below settings can be found here: https://github.com/buzzfeed/s
 ```
 SESSION_COOKIE_NAME     - string - name associated with the session cookie
 SESSION_COOKIE_SECRET   - string - seed string for secure cookies
-SESSION_COOKIE_DOMAIN   - string - cookie domain to force cookies to (ie: .yourcompany.com)*
+SESSION_COOKIE_DOMAIN   - string - cookie domain (and subdomains) to force cookies to (ie: .yourcompany.com)*
 SESSION_COOKIE_SECURE   - bool - set secure (HTTPS) cookie flag
 SESSION_COOKIE_HTTPONLY - bool - set 'httponly' cookie flag
 SESSION_TTL_LIFETIME    - time.Duration - 'time-to-live' of a session lifetime

--- a/docs/sso_proxy_config.md
+++ b/docs/sso_proxy_config.md
@@ -11,7 +11,9 @@ Defaults for the below settings can be found here: https://github.com/buzzfeed/s
 ```
 SESSION_COOKIE_NAME     - string - name associated with the session cookie
 SESSION_COOKIE_SECRET   - string - seed string for secure cookies
-SESSION_COOKIE_DOMAIN   - string - cookie domain (and subdomains) to force cookies to (ie: .yourcompany.com)*
+SESSION_COOKIE_DOMAIN   - string - cookie domain (and subdomains) to force cookies to (ie: .yourcompany.com). If this is set,
+cookies will be valid on subdomains too. To restrict to only the request's domain, leave this unset.
+Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent
 SESSION_COOKIE_SECURE   - bool - set secure (HTTPS) cookie flag
 SESSION_COOKIE_HTTPONLY - bool - set 'httponly' cookie flag
 SESSION_TTL_LIFETIME    - time.Duration - 'time-to-live' of a session lifetime

--- a/internal/pkg/sessions/cookie_store.go
+++ b/internal/pkg/sessions/cookie_store.go
@@ -3,6 +3,7 @@ package sessions
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -81,22 +82,21 @@ func NewCookieStore(cookieName string, optFuncs ...func(*CookieStore) error) (*C
 func (s *CookieStore) makeCookie(req *http.Request, name string, value string, expiration time.Duration, now time.Time) *http.Cookie {
 	logger := log.NewLogEntry()
 
-	// To avoid subdomains being inadvertently included, omit the domain attribute unless
-	// it's explicitly set in s.CookieDomain.
-	// https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.2.3
-	domain := ""
 	if s.CookieDomain != "" {
+		domain := req.Host
+		if h, _, err := net.SplitHostPort(domain); err == nil {
+			domain = h
+		}
 		if !strings.HasSuffix(domain, s.CookieDomain) {
 			logger.WithRequestHost(domain).WithCookieDomain(s.CookieDomain).Warn("Warning: Using explicitly configured cookie domain.")
 		}
-		domain = s.CookieDomain
 	}
 
 	return &http.Cookie{
 		Name:     name,
 		Value:    value,
 		Path:     "/",
-		Domain:   domain,
+		Domain:   s.CookieDomain,
 		HttpOnly: s.CookieHTTPOnly,
 		Secure:   s.CookieSecure,
 		Expires:  now.Add(expiration),

--- a/internal/pkg/sessions/cookie_store_test.go
+++ b/internal/pkg/sessions/cookie_store_test.go
@@ -104,12 +104,16 @@ func TestMakeSessionCookie(t *testing.T) {
 		expectedCookie *http.Cookie
 	}{
 		{
+			// In order to prevent subdomains being included, the Domain
+			// value is left empty by default.
+			// While empty, it defaults to the URL domain with subdomains _excluded_.
+			// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie
 			name: "default cookie domain",
 			expectedCookie: &http.Cookie{
 				Name:     cookieName,
 				Value:    cookieValue,
 				Path:     "/",
-				Domain:   "www.example.com",
+				Domain:   "",
 				HttpOnly: true,
 				Secure:   true,
 				Expires:  now.Add(expiration),
@@ -159,12 +163,16 @@ func TestMakeSessionCSRFCookie(t *testing.T) {
 		expectedCookie *http.Cookie
 	}{
 		{
+			// In order to prevent subdomains being included, the Domain
+			// value is left empty by default.
+			// While empty, it defaults to the URL domain with subdomains _excluded_.
+			// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie
 			name: "default cookie domain",
 			expectedCookie: &http.Cookie{
 				Name:     csrfName,
 				Value:    cookieValue,
 				Path:     "/",
-				Domain:   "www.example.com",
+				Domain:   "",
 				HttpOnly: true,
 				Secure:   true,
 				Expires:  now.Add(expiration),


### PR DESCRIPTION
## Problem
By default, we set the `Domain` attribute in the session cookie to the request's host value. This causes the cookie to be valid for the provided domain, **and all subdomains**. I don't believe this is expected behaviour, and shouldn't be the default. 

For reference: https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.2.3
> The Domain attribute specifies those hosts to which the cookie will
   be sent. For example, if the value of the Domain attribute is
   "example.com", the user agent will include the cookie in the Cookie
   header when making HTTP requests to example.com, www.example.com, and
   www.corp.example.com.
> ...
> If the server omits the Domain attribute, the user
   agent will return the cookie only to the origin server.

A leading `.` no longer has any impact on where the cookie is shared.

More references: [mozilla domain attribute](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#:~:text=be%20sent%20to.-,Domain%20attribute,-The%20Domain%20attribute), [mozilla set-cookie](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#:~:text=Age%20has%20precedence.-,Domain%3D%3Cdomain%2Dvalue%3E,-Optional)

## Solution

Unless a domain is explicitly specified in the configuration, set the domain value to `""` so that the cookie isn't shared with subdomains. Instead, it automatically defaults to _only_ the request's domain


