### PR TITLE
pkg/logging: Use RFC3339 compatible time format

### DIFF
--- a/internal/pkg/logging/logging.go
+++ b/internal/pkg/logging/logging.go
@@ -12,7 +12,7 @@ var serviceName = "sso"
 
 func init() {
 	logrus.SetOutput(os.Stdout)
-	logrus.SetFormatter(&logrus.JSONFormatter{TimestampFormat: "2006-01-02 15:04:05.000"})
+	logrus.SetFormatter(&logrus.JSONFormatter{TimestampFormat: "2006-01-02 15:04:05.000Z"})
 }
 
 // SetServiceName configures the service name to log with each LogEntry.


### PR DESCRIPTION
Signed-off-by: Nam Hai Nguyen <namhai.nguyen-ext@commercetools.com>

## Problem

Logging pkg doesn't use either RFC3339 or ISO 8601 time format, then we have to parse SSO logs specifically.

## Solution
Use a valid RFC 3339 time format.

Referece: https://ijmacd.github.io/rfc3339-iso8601/

## Notes

Other pertinent information. Examples: a walkthrough of how the solution might work, why this solution is optimal compared to other possible solutions, or further TODOs beyond this PR.
