### PR TITLE
Fixed handle errors when reading HTTP/1 request smuggling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,9 +15,9 @@ require (
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/rakyll/statik v0.1.7
 	github.com/sirupsen/logrus v1.4.2
-	golang.org/x/net v0.0.0-20190620200207-3b0461eec859 // indirect
+	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
-	golang.org/x/sync v0.0.0-20190423024810-112230192c58
+	golang.org/x/sync v0.1.0
 	golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898
 	google.golang.org/api v0.5.0
 	gopkg.in/yaml.v2 v2.2.2


### PR DESCRIPTION
A request smuggling attack is possible when using MaxBytesHandler. When using MaxBytesHandler, the body of an HTTP request is not fully consumed. When the server attempts to read HTTP2 frames from the connection, it will instead be reading the body of the HTTP request, which could be attacker-manipulated to represent arbitrary HTTP2 requests.

Not much that can be done now, but this essentially introduced a DOS vector into the http2 library without any release notes. While the comment is helpful, most users probably don't read the full diff of changes in core libraries like this. It would be nice to have more visibility into unsafe changes, or to make them opt-in, in the future.


